### PR TITLE
feat: deleted restore/list, default-category, first-run setup, and storage migration

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -2,8 +2,8 @@
 #
 # Adopted deliberately rather than inherited: this repository's early history
 # used a `(feat)` / `(chore)` parenthesized style that later commits dropped,
-# leaving no consistent convention. Everything from PR #34 onward uses
-# standard Conventional Commits.
+# leaving no consistent convention. Everything from the adoption point onward
+# uses standard Conventional Commits.
 #
 # Checked in CI by .github/workflows/rust.yml. There is no Node toolchain in
 # this repository and none is needed - the workflow runs commitlint in a
@@ -19,8 +19,7 @@ rules:
 
   # Scopes are optional, but when present should name the area touched, so
   # the log reads as a table of contents. Not an enum: the module layout is
-  # still moving (see issue #19), and a stale enum would reject honest
-  # scopes.
+  # still moving, and a stale enum would reject honest scopes.
   scope-case: [2, always, kebab-case]
 
   # `fix(storage): allow tasks in Uncategorized` - imperative, lower case, no

--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,32 @@
+# Conventional Commits enforcement.
+#
+# Adopted deliberately rather than inherited: this repository's early history
+# used a `(feat)` / `(chore)` parenthesized style that later commits dropped,
+# leaving no consistent convention. Everything from PR #34 onward uses
+# standard Conventional Commits.
+#
+# Checked in CI by .github/workflows/rust.yml. There is no Node toolchain in
+# this repository and none is needed - the workflow runs commitlint in a
+# container.
+extends:
+  - '@commitlint/config-conventional'
+
+rules:
+  # The default 100-character subject cap is tight for a change that needs to
+  # name a command and its issue. 72 is the git convention for the subject
+  # line; allow a little more rather than encouraging truncation.
+  header-max-length: [2, always, 88]
+
+  # Scopes are optional, but when present should name the area touched, so
+  # the log reads as a table of contents. Not an enum: the module layout is
+  # still moving (see issue #19), and a stale enum would reject honest
+  # scopes.
+  scope-case: [2, always, kebab-case]
+
+  # `fix(storage): allow tasks in Uncategorized` - imperative, lower case, no
+  # trailing period. These are config-conventional defaults, restated here
+  # because they are the rules contributors trip over most.
+  subject-case: [2, never, [sentence-case, start-case, pascal-case, upper-case]]
+  subject-empty: [2, never]
+  subject-full-stop: [2, never, '.']
+  type-empty: [2, never]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,44 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Conventional Commits, enforced only on pull requests.
+  #
+  # Deliberately NOT run on pushes to main: the history predating PR #34 does
+  # not follow the convention, and retroactively failing CI on it would be
+  # noise with nothing actionable behind it.
+  commitlint:
+    name: Commit messages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # commitlint needs the full range between base and head to know which
+        # commits belong to this PR; the default shallow clone hides them.
+        fetch-depth: 0
+
+    - name: Lint commit messages
+      uses: wagoid/commitlint-github-action@v6
+
+    # If this repository ever squash-merges, the commit that lands on main is
+    # the *pull request title*, not any of the commits linted above - so an
+    # unconventional title would silently become an unconventional commit on
+    # main. Checking it here keeps the rule true whichever merge strategy is
+    # used. Kept as a plain regex rather than a second commitlint invocation
+    # because it only needs to match the type/scope/subject shape.
+    - name: Lint pull request title
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9-]+\))?!?: .+'
+        if ! printf '%s' "$PR_TITLE" | grep -Eq "$pattern"; then
+          echo "::error::PR title is not a Conventional Commit: '$PR_TITLE'"
+          echo "Expected e.g. 'feat(storage): migrate data when storage.type changes'"
+          echo "Valid types: build chore ci docs feat fix perf refactor revert style test"
+          exit 1
+        fi
+        echo "PR title OK: $PR_TITLE"
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,9 +12,9 @@ env:
 jobs:
   # Conventional Commits, enforced only on pull requests.
   #
-  # Deliberately NOT run on pushes to main: the history predating PR #34 does
-  # not follow the convention, and retroactively failing CI on it would be
-  # noise with nothing actionable behind it.
+  # Deliberately NOT run on pushes to main: the older history does not follow
+  # the convention, and retroactively failing CI on it would be noise with
+  # nothing actionable behind it.
   commitlint:
     name: Commit messages
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,19 @@ Open and deliberately not started:
 - **#19 split `config.rs`** — it does three jobs (key schema/validation,
   persistence, backend construction). Collides with anything else touching
   config, so do it on a quiet tree.
-- **#20 / #21 tests and doc comments** — partly self-resolving as features land;
-  worth re-scoping rather than treating "TEST ALL THE THINGS" as a spec.
-- **#4** is effectively resolved by #27 and can likely be closed with a pointer.
+- **#20 / #21 tests and doc comments** — re-scoped from open-ended wishes into
+  checklists with an exit condition. #20's real gap is backend parity: most
+  behaviour is exercised against JSON only, which is how the SQLite
+  foreign-key bug shipped.
+- **#35 binary name** — the README specifies `trtodo`, `Cargo.toml` builds
+  `trusty_rusty_todo_list`. Fix is a `[[bin]]` stanza plus a rename of
+  `CARGO_BIN_EXE_*` across all seven test files.
+- **#36 category rename orphans `default-category`** — the setting stores a
+  name (IDs get recycled, which is worse), and nothing keeps it in step.
+- **#37 `JsonStorage::save` has no format check** — unreachable through
+  configuration, guarded only by the distinct-filenames invariant above.
+
+#4 is closed: all four of its bullets landed.
 
 ## Rough edges and session cost
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,24 @@ mistake the existing code for one.
   bearing, since most of this code encodes a decision someone will otherwise
   undo.
 
+## Code comments
+
+**No issue or PR numbers in comments.** Not `(issue #29)`, not `Issue #25:`,
+not `issue #22's second half`. Code has to be readable by someone who does not
+have the tracker open — which includes every session that starts cold.
+
+Write the reason instead of a pointer to it. If a comment currently leans on an
+issue number to carry its meaning ("the entire point of issue #29's design"),
+that is a comment missing its actual content: say *what* the design is and why
+("the entire point of soft deletion keeping the real `category_id`").
+
+Backlog links belong in commit messages and pull requests, where `Closes #NN`
+is expected and traceability already lives.
+
 ## Commit conventions
 
 [Conventional Commits](https://www.conventionalcommits.org/), enforced by
-commitlint in CI on pull requests (not on `main` — history before PR #34 predates
+commitlint in CI on pull requests (not on `main` — the older history predates
 the convention). The PR title is linted too, because a squash-merge makes the
 title the commit that lands on `main`.
 
@@ -129,11 +143,15 @@ Open and deliberately not started:
   worth re-scoping rather than treating "TEST ALL THE THINGS" as a spec.
 - **#4** is effectively resolved by #27 and can likely be closed with a pointer.
 
-Two known gaps, both filed nowhere yet:
+## Rough edges and session cost
 
-- Renaming a category silently orphans a `default-category` setting that names
-  it (the setting stores a name, deliberately — IDs are reused after delete,
-  which is worse).
-- `JsonStorage::save` is a bare `fs::write` with no format check. Not reachable
-  through configuration now that backends have distinct filenames, but a direct
-  constructor call could still have JSON clobber a SQLite file.
+`docs/WORKING-NOTES.md` covers what this file deliberately leaves out: known
+defects not yet filed (the binary is built as `trusty_rusty_todo_list`, not the
+documented `trtodo`; renaming a category orphans `default-category`), build
+facts that surprise people (`cargo test --lib` fails — there is no lib target;
+`rusqlite` is bundled, so never delete `target/`), and the practices that keep
+an AI-assisted session from spending its budget re-deriving known things.
+
+Read it before parallelizing work across subagents or scoping a branch from an
+issue — those are the two places this project has historically wasted the most
+effort.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,139 @@
+# trusty_rusty_todo_list
+
+A CLI todo list in Rust. Binary name is `trtodo`. Tasks belong to categories;
+configuration and data live under `~/.config/trtodo` by default.
+
+`README.md` is the specification, not just documentation. Where behavior and
+README disagree, that is a bug in one of them — decide which, and fix that one.
+Several past issues came from code drifting away from what the README promised.
+
+## Commands
+
+```sh
+cargo build
+cargo test                        # unit + integration
+cargo fmt --all -- --check        # exactly what CI runs
+cargo clippy -- -D warnings       # exactly what CI runs
+```
+
+CI (`.github/workflows/rust.yml`) runs those three plus commitlint. Run all
+three before pushing; `clippy -- -D warnings` is stricter than a bare
+`cargo clippy` and will fail the build on a warning.
+
+## Layout
+
+| Path | Responsibility |
+| --- | --- |
+| `src/main.rs` | Thin dispatch. Parses, opens storage, matches commands, prints. Resolution helpers (`resolve_add_category`, `resolve_task_scope`, `require_category_context`) live here because they need both config and storage. |
+| `src/cli.rs` | clap definitions only. No behavior. Unit tests assert parsing. |
+| `src/config.rs` | Config schema, validation, persistence. Knows nothing about tasks. |
+| `src/models/` | `Task`, `Category`, `Priority`, `StorageData`, error types. |
+| `src/storage/` | `Storage` trait plus `json` and `sqlite` backends, `config.rs` (config file store), `migrate_storage`. |
+| `src/category_manager.rs` | Category CRUD and the `category use` context. |
+| `src/task_manager.rs` | Task operations, task resolution, disambiguation. |
+| `src/prompter.rs` | The interactive-input seam. See below. |
+| `tests/` | Integration tests that shell out to the built binary. |
+
+Rough layering: `main` → managers → `storage` → `models`. `storage` referencing
+`category_manager::UNCATEGORIZED_ID` is the one deliberate exception.
+
+## Invariants that bite
+
+These are the things that have actually caused bugs. Read before touching the
+related area.
+
+**`Uncategorized` (ID 0) is synthesized, never stored.** `CategoryManager`
+builds it on demand; `get_next_category_id` never hands out 0. Consequences:
+
+- `CategoryManager::list_categories` drops any stored row with ID 0 and
+  substitutes its own.
+- SQLite has a `tasks.category_id` foreign key, so a task in Uncategorized
+  references a row that does not otherwise exist. `SqliteStorage::save` seeds a
+  sentinel row and `load` filters it back out. **Do not "clean up" either half** —
+  removing the seed makes every uncategorized task unstorable under SQLite;
+  removing the filter makes a fresh SQLite store look established and silently
+  suppresses the first-run offer.
+
+**`has_explicit_category_context()` is not `get_current_category().is_some()`.**
+`get_current_category` returns `Some(UNCATEGORIZED_ID)` even when no context was
+ever set, so `category show` has something to print. Any code deciding *"did the
+user choose a category?"* must use `has_explicit_category_context`. Using the
+other one collapses fallback chains silently — this is exactly how
+`default-category` came to be ignored for so long.
+
+**Never call `stdin().read_line()` directly.** All interactive input goes through
+the `Prompter` trait (`choose`, `confirm`). `StdinPrompter` detects a
+non-interactive stdin and returns `PromptError::NotInteractive` instead of
+blocking; `NonInteractivePrompter` backs `--yes`/`--no-input`;
+`ScriptedPrompter` is for unit tests. This seam is why prompts can be tested
+without a TTY, and why nothing hangs in CI.
+
+**Soft deletion is a `deleted_at` timestamp, not a magic category.** A deleted
+task keeps its real `category_id` so restore is lossless. `live_tasks()` excludes
+them; `get_deleted_tasks()` returns them. `list`/`search` must go through
+`live_tasks()`.
+
+**Each storage backend owns its own file** inside the `storage.path` *directory*
+(`trtodo-data.json`, `trtodo-data.db`). They must never point at the same path.
+Changing `storage.type` migrates data via `migrate_storage`, which only ever
+reads the source and refuses to overwrite a non-empty destination.
+
+**SQLite schema versioning is a guard rail, not a migration system.**
+`SCHEMA_VERSION` is 2. `initialize_schema` reads the stored version before
+touching any table and rejects anything newer. There is one hand-written v1→v2
+step (adding `deleted_at`). Adding a real migration system is deferred — do not
+mistake the existing code for one.
+
+## Testing conventions
+
+- Integration tests in `tests/` build and invoke the real binary. They **must**
+  pass `--config` pointed at a `TempDir` so they never touch the real `$HOME`.
+  There is no exception to this.
+- Prompt-dependent paths are tested via `ScriptedPrompter` (unit) or by asserting
+  the non-interactive error (integration) — never by piping `"y\n"` at a
+  subprocess.
+- Doc comments here are unusually dense and explain *why*, including why
+  alternatives were rejected. Match that; it is the house style and it is load
+  bearing, since most of this code encodes a decision someone will otherwise
+  undo.
+
+## Commit conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/), enforced by
+commitlint in CI on pull requests (not on `main` — history before PR #34 predates
+the convention). The PR title is linted too, because a squash-merge makes the
+title the commit that lands on `main`.
+
+```
+feat(storage): migrate data when storage.type changes
+fix(add): reject an unresolvable default-category
+```
+
+Bodies should explain the reasoning, and end with `Closes #NN` where applicable.
+
+## State as of PR #34
+
+PR #34 closes #17, #25, #27, #31, #32, #33. It was built as four parallel
+branches and merged; the history was then linearized into five conventional
+commits.
+
+Open and deliberately not started:
+
+- **#16 category ordering** — needs an `order` field honored across both
+  backends plus a reorder command. `Category.order` already exists and is
+  persisted, but nothing lets a user set it.
+- **#19 split `config.rs`** — it does three jobs (key schema/validation,
+  persistence, backend construction). Collides with anything else touching
+  config, so do it on a quiet tree.
+- **#20 / #21 tests and doc comments** — partly self-resolving as features land;
+  worth re-scoping rather than treating "TEST ALL THE THINGS" as a spec.
+- **#4** is effectively resolved by #27 and can likely be closed with a pointer.
+
+Two known gaps, both filed nowhere yet:
+
+- Renaming a category silently orphans a `default-category` setting that names
+  it (the setting stores a name, deliberately — IDs are reused after delete,
+  which is worse).
+- `JsonStorage::save` is a bare `fs::write` with no format check. Not reachable
+  through configuration now that backends have distinct filenames, but a direct
+  constructor call could still have JSON clobber a SQLite file.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ The binary named `trtodo` will accept various arguments
 | `trtodo config set <key=value>`                                                                       | Set configuration key to value                                                                                                            |
 | `trtodo config default <key>`                                                                         | Unsets the value for key to force use of the default value                                                                                |
 | `trtodo config list`                                                                                  | List all configuration keys and their values, including defaults which will be indicated with an asterisk                                 |
-| `trtodo deleted flush`                                                                                | Remove all deleted items from "Deleted" category                                                                                          |
+| `trtodo deleted list`                                                                                 | List all soft-deleted tasks with their IDs, titles, original categories, and deletion dates - i.e. exactly what a `flush` would destroy   |
+| `trtodo deleted restore <title or id>`                                                                | Restore a soft-deleted task to its original category. Matches soft-deleted tasks only, prompting if the title is ambiguous                |
+| `trtodo deleted flush [--yes (or -y, --force)]`                                                       | Permanently remove all soft-deleted tasks, listing them and asking for confirmation first. `--yes` skips the prompt                       |
 | `trtodo --help`                                                                                       | List these commands                                                                                                                       |
 | `trtodo --help <command>`                                                                             | Describe command and its arguments                                                                                                        |
 | `trtodo --config <path>`                                                                              | Uses the configuration file at the given path instead of the default. May also be set via the `TRTODO_CONFIG` environment variable; the flag wins  |
@@ -54,6 +56,10 @@ The first time `trtodo` is run it should offer to create the default categories 
 When operating on a `task_name`, the application will try to match the name - if it encounters the same name in multiple categories, it will prompt the user for which item on which to operate.
 
 When deleting an item it will be _soft_deleted_: it is marked with a deletion timestamp but keeps its real category, so restoring it is lossless. Soft-deleted items are hidden from listings and searches, and are purged automatically after `deleted-task-lifespan` days (0, the default, means never).
+
+Because soft-deleted tasks are hidden everywhere else, the `deleted` namespace is where they can be seen and acted on. `deleted list` shows them, oldest deletion first - the order in which a flush or the automatic purge reaches them. `deleted restore` puts one back in the category it was deleted from; it resolves its argument among soft-deleted tasks only, so it can never match a live task, and it takes no `--category` (run `deleted list` to get the ID).
+
+`deleted flush` is the only irreversible command in the application, so it lists what it is about to destroy and asks for confirmation before doing it. Confirmation is skipped with `--yes` (also spelled `-y` or `--force`). With no terminal attached - a pipe, a script, CI - there is nobody to ask, so a `flush` without `--yes` **refuses and exits non-zero** rather than destroying data unattended; scripts that mean it can say so with `--yes`. Flushing when nothing is soft-deleted has nothing at stake and so is a silent no-op that never prompts.
 
 When deleting a category it is removed and its ID is made available again. All associated tasks are moved to the top unless a new category is provided.
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,18 @@ The binary named `trtodo` will accept various arguments
 | `trtodo --help`                                                                                       | List these commands                                                                                                                       |
 | `trtodo --help <command>`                                                                             | Describe command and its arguments                                                                                                        |
 | `trtodo --config <path>`                                                                              | Uses the configuration file at the given path instead of the default. May also be set via the `TRTODO_CONFIG` environment variable; the flag wins  |
+| `trtodo --yes` (or `-y`)                                                                              | Assume "yes" for confirmation prompts and never read from stdin                                                                           |
+| `trtodo --no-input`                                                                                   | Never prompt: decline confirmations and never read from stdin                                                                             |
 
 ## Additional Behaviors
 
 The first time `trtodo` is run it should offer to create the default categories of "Home" and "Work" and create a configuration file under `.config\trtodo\` or `C:\\Users\\<username>\\AppData\\Roaming\trtodo`.
+
+That offer defaults to yes (a bare Enter accepts it) and is made at most once:
+
+- It is made by the first command that touches task storage, not by `trtodo config ...`. Config commands never open task storage, and creating categories from a read-only `config list` - or from the very `config set storage.path=...` that decides where task data belongs - would put data somewhere the user did not ask for.
+- The answer is recorded in the configuration file, so no later run asks again. Accepting, declining, and already having categories (an existing install, upgraded or otherwise) all count as answered; deleting every category afterwards is a legitimate empty state and does not bring the offer back.
+- With no terminal attached (a pipe, a cron job, CI) there is nobody to ask, so the offer is silently skipped: nothing is created, nothing is recorded, and nothing blocks waiting for input. Pass `--yes` or `--no-input` to give a definite answer from a script.
 
 When operating on a `task_name`, the application will try to match the name - if it encounters the same name in multiple categories, it will prompt the user for which item on which to operate.
 
@@ -70,6 +78,8 @@ Category context (set via `category use`) persists between runs of the applicati
 ## Configuration Values
 
 Configuration values are stored in `trtodo-config.json`. By default it's written to a config folder unless it's first read in your home directory. 
+
+The keys below are the configurable ones - they are exactly what `config set`, `config default`, and `config list` operate on. The file may also contain internal bookkeeping that is not a setting (currently `default_categories_offered`, which records that the first-run offer above has been answered); those are not listed by `config list` and cannot be set with `config set`.
 
 | Config Key              | Default Value      | Options             | Description                                                                                                                           |
 | ----------------------- | ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -70,3 +70,18 @@ Configuration values are stored in `trtodo-config.json`. By default it's written
 | `storage.path`          | `~/.config/trtodo` | string              | Path to storage location                                                                                                              |
 | `default-category`      | `null`             | string              | Default category to use when no category is specified                                                                                 |
 | `default-priority`      | `medium`           | `high\|medium\|low` | Default priority for new tasks                                                                                                        |
+
+### Storage backends
+
+`storage.path` is a *directory*. Each backend keeps its own data file inside it, so they can never be pointed at the same file and overwrite one another:
+
+| `storage.type` | Data file          |
+| -------------- | ------------------ |
+| `json`         | `trtodo-data.json` |
+| `sqlite`       | `trtodo-data.db`   |
+
+Because of that, changing `storage.type` moves your tasks and categories to the new backend's file:
+
+- If the backend you are leaving has data and the one you are switching to is empty, everything (including task and category IDs, and your `category use` context) is copied across. The old file is left exactly as it was, so switching back always gets you to it.
+- If the backend you are switching to *already* has tasks or categories of its own, nothing is copied and nothing is overwritten. You are told what is in each store and how to switch back. The two are never merged, because merging would mean renumbering IDs.
+- If there is nothing to move, the switch is silent.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The binary named `trtodo` will accept various arguments
 
 | Command                                                                                               | Description                                                                                                                               |
 | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `trtodo add <title> --category <category_name or category_id> (or -c) [--priority <high|medium|low>]` | Add a new task with the given title and optional priority                                                                                 |
+| `trtodo add <title> [--category <category_name or category_id> (or -c)] [--priority <high|medium|low>]` | Add a new task with the given title and optional priority. Omitting `--category` uses the current category context, else `default-category`, else Uncategorized |
 | `trtodo delete <title or id> [--category <category_name or category_id> (or -c)]`                     | Delete the task with the given title                                                                                                      |
 | `trtodo update <title or id> --to <new_title> [--category <category_name or category_id> (or -c)]`    | Update the task with the given title                                                                                                      |
 | `trtodo check (x, mark) <title or id> --category <category_name or category_id> (or -c)`              | Check off the task with the given title                                                                                                   |
@@ -65,6 +65,8 @@ When deleting a category it is removed and its ID is made available again. All a
 
 Category context (set via `category use`) persists between runs of the application. When in a category context, commands that require category specification can omit the `--category` argument.
 
+`add` cannot fall back to searching every category the way `delete`/`update`/`check`/`uncheck` do - a new task has to land somewhere definite - so it resolves its category in strict order: an explicit `--category`, then the current category context, then the `default-category` config value, then Uncategorized. The category context deliberately outranks `default-category`: `category use` is a deliberate "I am working here right now", so `category use` temporarily overrides the configured default and `category clear` returns to it.
+
 ## Configuration Values
 
 Configuration values are stored in `trtodo-config.json`. By default it's written to a config folder unless it's first read in your home directory. 
@@ -74,7 +76,7 @@ Configuration values are stored in `trtodo-config.json`. By default it's written
 | `deleted-task-lifespan` | `0`                | integer<1..?>       | Number of days before task in Deleted category are deleted. A value of 0, the default, indicates they are never automatically deleted |
 | `storage.type`          | `json`             | `json\|sqlite`      | Type of storage backend to use                                                                                                        |
 | `storage.path`          | `~/.config/trtodo` | string              | Path to storage location                                                                                                              |
-| `default-category`      | `null`             | string              | Default category to use when no category is specified                                                                                 |
+| `default-category`      | `null`             | string              | Category `add` files new tasks into when no `--category` is given and no category context is set. Must name an existing category (by name or ID) - `add` reports an error rather than guessing if it no longer resolves. Renaming a category does not update this setting |
 | `default-priority`      | `medium`           | `high\|medium\|low` | Default priority for new tasks                                                                                                        |
 
 ### Storage backends

--- a/docs/WORKING-NOTES.md
+++ b/docs/WORKING-NOTES.md
@@ -1,0 +1,151 @@
+# Working notes
+
+Two things that don't belong in `CLAUDE.md` because they aren't needed on
+every turn: the rough edges worth knowing before you touch something, and the
+practices that keep an AI-assisted session from burning budget re-deriving
+what is already known.
+
+`CLAUDE.md` holds the invariants — the rules you must not break. This file
+holds the friction: what is currently wrong, what will waste your time, and
+how to spend fewer tokens getting the same work done.
+
+---
+
+## Rough edges
+
+### The binary is not called `trtodo`
+
+`README.md` line 21 says "The binary named `trtodo`", and every row of the
+command table spells commands as `trtodo ...`. But `Cargo.toml` has no
+`[[bin]]` section, so the binary takes the package name: `cargo build`
+produces `target/debug/trusty_rusty_todo_list`.
+
+Nothing is broken by this today — the integration tests find the binary
+through `env!("CARGO_BIN_EXE_trusty_rusty_todo_list")`, which cargo generates
+from the real target name — but the documented install does not produce the
+documented command. By this repo's own rule (the README is the spec), this is
+a bug in `Cargo.toml`, not in the README.
+
+The fix is one stanza plus a mechanical rename:
+
+```toml
+[[bin]]
+name = "trtodo"
+path = "src/main.rs"
+```
+
+...and then `CARGO_BIN_EXE_trusty_rusty_todo_list` → `CARGO_BIN_EXE_trtodo`
+in all seven files under `tests/`. Deliberately not done yet: it is a real
+change with a blast radius, and it deserves its own commit rather than
+riding along with unrelated work.
+
+### Two gaps that are filed nowhere
+
+- **Renaming a category orphans a `default-category` that names it.** The
+  setting stores a name on purpose (IDs are handed back out after a delete,
+  so a stored ID can silently start pointing at an unrelated category). The
+  consequence is that `category update Work Werk` leaves
+  `default-category=Work` dangling, and the next bare `add` fails to resolve
+  it. Renaming should probably follow the setting across.
+
+- **`JsonStorage::save` is a bare `fs::write` with no format check.** Not
+  reachable through configuration now that each backend owns a distinct
+  filename, but a direct constructor call could still have JSON clobber a
+  SQLite file. The distinct filenames are what make this unreachable — see
+  the warning in `CLAUDE.md` about not "cleaning up" that arrangement.
+
+### Build and test facts that surprise people
+
+- **There is no lib target.** `cargo test --lib` fails outright with `no
+  library targets found in package`. The ~99 unit tests live in the binary
+  target alongside the 50 integration tests. Use plain `cargo test`, or
+  `cargo test --bin trusty_rusty_todo_list` to skip the integration suites.
+
+- **`rusqlite` is vendored with `features = ["bundled"]`**, so a cold build
+  compiles SQLite from C source and takes minutes. A warm build takes
+  seconds. Never delete `target/` to "start clean" — it is the single most
+  expensive thing you can do to a session, and it fixes nothing that
+  `cargo clean -p trusty_rusty_todo_list` wouldn't fix faster.
+
+- **`cargo clippy -- -D warnings` is stricter than bare `cargo clippy`.**
+  CI runs the strict form. A bare clippy run that looks clean proves
+  nothing about whether CI will pass.
+
+- **Current state:** 149 tests across 7 binaries (99 unit + 3 + 3 + 14 + 7
+  + 6 + 17). If that total drops, something was deleted rather than fixed.
+
+---
+
+## Keeping sessions cheap
+
+Ordered by how much each one actually cost or saved when this code was
+being worked on — not by how good the advice sounds.
+
+### 1. Don't fan out subagents for work that isn't big and genuinely parallel
+
+The single largest avoidable cost. Every subagent starts cold: it re-reads
+the same files, re-derives the same invariants, and re-discovers the same
+constraints the parent already knows. Four agents on four issues meant
+paying the discovery tax four times for one codebase.
+
+It is worth it when the tasks are large, touch disjoint files, and would
+serialize badly otherwise. It is *not* worth it for anything you could do
+inline in a few tool calls. A task described as "thorough" or having
+"several parts" is not by itself a reason to spawn anything.
+
+### 2. Isolated agents cannot see integration bugs — budget for the merge
+
+Four features that each pass their own tests can still combine into a
+failure none of them could see. That happened here: making `--category`
+optional turned Uncategorized into the default landing place for `add`,
+which walked straight into a SQLite foreign-key constraint that only
+existed because Uncategorized is synthesized rather than stored. Every
+individual branch was green.
+
+If you parallelize, reserve real budget for a combined smoke test that
+exercises the features *against each other*, not just a merge that compiles.
+
+### 3. Check the issue against the code before scoping work from it
+
+Issue text goes stale. One issue here asserted that `SCHEMA_VERSION` was
+"a hardcoded 1" and proposed deleting the version table on that basis; the
+constant was actually `2`, with a real v1→v2 migration behind it. Acting on
+the issue as written would have destroyed history.
+
+One `grep` before scoping is cheaper than one wrong branch.
+
+### 4. Decide the commit convention before branching, not after
+
+Retrofitting Conventional Commits onto four already-merged branches meant
+cherry-picking, re-resolving conflicts that had already been resolved once,
+and verifying by tree hash that the rewritten history still produced
+identical output. That verification was worth doing — it caught a
+duplicated README row — but the whole exercise was avoidable by deciding
+the format up front.
+
+### 5. Read ranges, not whole files
+
+Four files here are 700–1100 lines. Reading one end to end to change a
+comment near the bottom costs the whole file every time. `grep -n` for the
+anchor, then read the range around it.
+
+Conversely: don't re-read a file immediately after editing it to "check"
+the edit. A failed edit reports itself.
+
+### 6. Run the full CI trio once, at the end
+
+`cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test`.
+Running all three after every small edit triples the cost of iterating for
+no added signal. Run `cargo check` while working; run the trio before
+pushing.
+
+### 7. Let `CLAUDE.md` do its job
+
+It is loaded automatically at session start. That is precisely why it must
+stay short and stay true: everything in it is paid for on every single
+session, so a stale line there is worse than a stale line anywhere else in
+the repo. If something in it is wrong, fixing it is high-value work, not
+housekeeping.
+
+Anything that is *not* needed every turn — including everything in this
+file — belongs somewhere `CLAUDE.md` merely points at.

--- a/docs/WORKING-NOTES.md
+++ b/docs/WORKING-NOTES.md
@@ -26,7 +26,7 @@ from the real target name — but the documented install does not produce the
 documented command. By this repo's own rule (the README is the spec), this is
 a bug in `Cargo.toml`, not in the README.
 
-The fix is one stanza plus a mechanical rename:
+Filed as #35. The fix is one stanza plus a mechanical rename:
 
 ```toml
 [[bin]]
@@ -39,16 +39,16 @@ in all seven files under `tests/`. Deliberately not done yet: it is a real
 change with a blast radius, and it deserves its own commit rather than
 riding along with unrelated work.
 
-### Two gaps that are filed nowhere
+### Two further gaps
 
-- **Renaming a category orphans a `default-category` that names it.** The
+- **Renaming a category orphans a `default-category` that names it** (#36). The
   setting stores a name on purpose (IDs are handed back out after a delete,
   so a stored ID can silently start pointing at an unrelated category). The
   consequence is that `category update Work Werk` leaves
   `default-category=Work` dangling, and the next bare `add` fails to resolve
   it. Renaming should probably follow the setting across.
 
-- **`JsonStorage::save` is a bare `fs::write` with no format check.** Not
+- **`JsonStorage::save` is a bare `fs::write` with no format check** (#37). Not
   reachable through configuration now that each backend owns a distinct
   filename, but a direct constructor call could still have JSON clobber a
   SQLite file. The distinct filenames are what make this unreachable — see

--- a/src/category_manager.rs
+++ b/src/category_manager.rs
@@ -478,8 +478,8 @@ mod tests {
         assert_eq!(categories.len(), 2); // Uncategorized + Test
     }
 
-    /// Issue #16 / README: "when deleting a category it is removed and its ID
-    /// is made available again."
+    /// README: "when deleting a category it is removed and its ID is made
+    /// available again."
     #[test]
     fn test_deleted_category_id_is_reused() {
         let test_storage = TestStorage::new();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,8 +22,8 @@ pub struct Cli {
     )]
     pub config: Option<PathBuf>,
 
-    // These two are the non-interactive escape hatch for scripts and CI
-    // (issue #27): they let an invocation answer the first-run offer of the
+    // These two are the non-interactive escape hatch for scripts and CI:
+    // they let an invocation answer the first-run offer of the
     // default categories without a terminal, so automation is never blocked
     // waiting on input. Questions with no yes/no answer - picking between
     // several tasks that share a name - are still refused under both flags
@@ -211,11 +211,11 @@ pub enum CategoryCommands {
 }
 
 /// The `deleted` namespace: everything you can do with the tasks that
-/// `trtodo delete` soft-deleted (issue #29's `deleted_at` timestamp).
+/// `trtodo delete` soft-deleted (the `deleted_at` timestamp).
 ///
 /// `list` and `restore` were previously absent on the grounds that the
-/// README documented only `flush`; issues #31 and #32 settled that surface
-/// and the README now documents all three. They are not optional extras:
+/// README documented only `flush`; the README now documents all three.
+/// They are not optional extras:
 /// soft-deleted tasks are hidden from `list` and `search`, so without
 /// `deleted list` they are invisible right up until `flush` destroys them,
 /// and without `deleted restore` a soft delete is just a slower hard delete.
@@ -287,7 +287,7 @@ mod tests {
         assert_eq!(cli.config, None);
     }
 
-    /// The non-interactive flags for issue #27's first-run offer. Both are
+    /// The non-interactive flags for the first-run offer. Both are
     /// global (usable before or after the subcommand) and mutually
     /// exclusive - "assume yes" and "assume no" cannot both hold.
     #[test]
@@ -326,7 +326,7 @@ mod tests {
             _ => panic!("Expected Add command"),
         }
 
-        // `--category` is optional (issue #33): omitting it parses cleanly and
+        // `--category` is optional: omitting it parses cleanly and
         // leaves resolution to `main::resolve_add_category`.
         let cli = parse_args(&["trtodo", "add", "Buy milk"]);
         match cli.command {
@@ -514,8 +514,8 @@ mod tests {
 
     #[test]
     fn test_required_arguments() {
-        // `add` used to require `--category`; issue #33 made it optional so
-        // the `category use` context and the `default-category` config value
+        // `add` used to require `--category`; it is now optional so the
+        // `category use` context and the `default-category` config value
         // can supply it. Parsing must therefore *succeed* without it - the
         // decision of where the task lands moved to `main`, which has the
         // storage and config access needed to make it.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,27 @@ pub struct Cli {
     )]
     pub config: Option<PathBuf>,
 
+    // These two are the non-interactive escape hatch for scripts and CI
+    // (issue #27): they let an invocation answer the first-run offer of the
+    // default categories without a terminal, so automation is never blocked
+    // waiting on input. Questions with no yes/no answer - picking between
+    // several tasks that share a name - are still refused under both flags
+    // rather than guessed at; see `prompter::NonInteractivePrompter`.
+    /// Assume "yes" for confirmation prompts and never read from stdin
+    ///
+    /// Accepts the first-run offer to create the default categories without
+    /// asking. Questions that aren't yes/no (such as which of several
+    /// same-named tasks you meant) are still refused rather than guessed at.
+    #[arg(long = "yes", short = 'y', global = true, conflicts_with = "no_input")]
+    pub yes: bool,
+
+    /// Never prompt; decline confirmations and never read from stdin
+    ///
+    /// The counterpart to --yes. Declining the first-run offer is a real
+    /// answer, so it is remembered and never asked again.
+    #[arg(long = "no-input", global = true)]
+    pub no_input: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -264,6 +285,29 @@ mod tests {
         // Absent by default, so ConfigManager falls back to the $HOME location.
         let cli = parse_args(&["trtodo", "config", "list"]);
         assert_eq!(cli.config, None);
+    }
+
+    /// The non-interactive flags for issue #27's first-run offer. Both are
+    /// global (usable before or after the subcommand) and mutually
+    /// exclusive - "assume yes" and "assume no" cannot both hold.
+    #[test]
+    fn test_non_interactive_flags() {
+        let cli = parse_args(&["trtodo", "--yes", "list"]);
+        assert!(cli.yes);
+        assert!(!cli.no_input);
+
+        let cli = parse_args(&["trtodo", "list", "-y"]);
+        assert!(cli.yes);
+
+        let cli = parse_args(&["trtodo", "list", "--no-input"]);
+        assert!(cli.no_input);
+        assert!(!cli.yes);
+
+        let cli = parse_args(&["trtodo", "list"]);
+        assert!(!cli.yes);
+        assert!(!cli.no_input);
+
+        assert!(try_parse_args(&["trtodo", "--yes", "--no-input", "list"]).is_err());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,9 +32,10 @@ pub enum Commands {
     Add {
         /// Title of the task
         title: String,
-        /// Category name or ID
+        /// Category name or ID. Omit to use the current category context, then
+        /// the `default-category` config value, then Uncategorized.
         #[arg(short = 'c', long = "category")]
-        category: String,
+        category: Option<String>,
         /// Priority level
         #[arg(short = 'p', long = "priority")]
         priority: Option<Priority>,
@@ -275,7 +276,23 @@ mod tests {
                 priority,
             } => {
                 assert_eq!(title, "Buy milk");
-                assert_eq!(category, "Home");
+                assert_eq!(category, Some("Home".to_string()));
+                assert!(priority.is_none());
+            }
+            _ => panic!("Expected Add command"),
+        }
+
+        // `--category` is optional (issue #33): omitting it parses cleanly and
+        // leaves resolution to `main::resolve_add_category`.
+        let cli = parse_args(&["trtodo", "add", "Buy milk"]);
+        match cli.command {
+            Commands::Add {
+                title,
+                category,
+                priority,
+            } => {
+                assert_eq!(title, "Buy milk");
+                assert!(category.is_none());
                 assert!(priority.is_none());
             }
             _ => panic!("Expected Add command"),
@@ -298,7 +315,7 @@ mod tests {
                 priority,
             } => {
                 assert_eq!(title, "Buy milk");
-                assert_eq!(category, "Home");
+                assert_eq!(category, Some("Home".to_string()));
                 assert_eq!(priority, Some(Priority::High));
             }
             _ => panic!("Expected Add command"),
@@ -453,8 +470,16 @@ mod tests {
 
     #[test]
     fn test_required_arguments() {
-        // Test that category is required for add command
+        // `add` used to require `--category`; issue #33 made it optional so
+        // the `category use` context and the `default-category` config value
+        // can supply it. Parsing must therefore *succeed* without it - the
+        // decision of where the task lands moved to `main`, which has the
+        // storage and config access needed to make it.
         let result = try_parse_args(&["trtodo", "add", "Buy milk"]);
+        assert!(result.is_ok());
+
+        // A title is still required, though: nothing can supply that.
+        let result = try_parse_args(&["trtodo", "add"]);
         assert!(result.is_err());
 
         // Test that priority must be valid

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -188,15 +188,38 @@ pub enum CategoryCommands {
     List,
 }
 
-/// README: `trtodo deleted flush` - "Remove all deleted items". `deleted
-/// list` (to preview what a flush would destroy) and restoring a
-/// soft-deleted task are deliberately not here: neither is documented in the
-/// README or part of issue #6's scope, and `Task::restore` stays unwired for
-/// the same reason.
+/// The `deleted` namespace: everything you can do with the tasks that
+/// `trtodo delete` soft-deleted (issue #29's `deleted_at` timestamp).
+///
+/// `list` and `restore` were previously absent on the grounds that the
+/// README documented only `flush`; issues #31 and #32 settled that surface
+/// and the README now documents all three. They are not optional extras:
+/// soft-deleted tasks are hidden from `list` and `search`, so without
+/// `deleted list` they are invisible right up until `flush` destroys them,
+/// and without `deleted restore` a soft delete is just a slower hard delete.
 #[derive(Subcommand)]
 pub enum DeletedCommands {
+    /// List all soft-deleted tasks, showing what a flush would destroy
+    List,
+    /// Restore a soft-deleted task to its original category
+    Restore {
+        /// Title or ID of the soft-deleted task
+        ///
+        /// Resolved among soft-deleted tasks only, so this can never
+        /// accidentally match a live task. There is no `--category`: run
+        /// `deleted list` to see the IDs.
+        title_or_id: String,
+    },
     /// Permanently remove all soft-deleted tasks
-    Flush,
+    Flush {
+        /// Skip the confirmation prompt
+        ///
+        /// Required when running non-interactively (piped stdin, CI,
+        /// scripts): with no terminal to confirm at, `flush` refuses rather
+        /// than destroying data unattended.
+        #[arg(short = 'y', long = "yes", visible_alias = "force")]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -375,14 +398,57 @@ mod tests {
 
     #[test]
     fn test_deleted_commands() {
-        // Test deleted flush
-        let cli = parse_args(&["trtodo", "deleted", "flush"]);
+        // Test deleted list
+        let cli = parse_args(&["trtodo", "deleted", "list"]);
         match cli.command {
             Commands::Deleted { command } => match command {
-                DeletedCommands::Flush => {}
+                DeletedCommands::List => {}
+                _ => panic!("Expected Deleted List command"),
             },
             _ => panic!("Expected Deleted command"),
         }
+
+        // Test deleted restore
+        let cli = parse_args(&["trtodo", "deleted", "restore", "Buy milk"]);
+        match cli.command {
+            Commands::Deleted { command } => match command {
+                DeletedCommands::Restore { title_or_id } => {
+                    assert_eq!(title_or_id, "Buy milk");
+                }
+                _ => panic!("Expected Deleted Restore command"),
+            },
+            _ => panic!("Expected Deleted command"),
+        }
+
+        // Test deleted flush: confirmation is opt-out, so `yes` is false
+        // unless the escape hatch was passed.
+        let cli = parse_args(&["trtodo", "deleted", "flush"]);
+        match cli.command {
+            Commands::Deleted { command } => match command {
+                DeletedCommands::Flush { yes } => assert!(!yes),
+                _ => panic!("Expected Deleted Flush command"),
+            },
+            _ => panic!("Expected Deleted command"),
+        }
+
+        // ... in any of its three spellings.
+        for flag in ["--yes", "-y", "--force"] {
+            let cli = parse_args(&["trtodo", "deleted", "flush", flag]);
+            match cli.command {
+                Commands::Deleted { command } => match command {
+                    DeletedCommands::Flush { yes } => assert!(yes, "{flag} should confirm"),
+                    _ => panic!("Expected Deleted Flush command"),
+                },
+                _ => panic!("Expected Deleted command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_deleted_restore_requires_a_task_reference() {
+        // Nothing sensible to restore without one, and defaulting to "all"
+        // would be a surprising thing to do by accident.
+        assert!(try_parse_args(&["trtodo", "deleted", "restore"]).is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -316,7 +316,21 @@ impl ConfigManager {
                 config.storage_path = Some(path.to_string_lossy().to_string());
             }
             "default-category" => {
-                // Note: Category validation would happen here once we have access to the storage layer
+                // Still stored without checking that the category exists, and
+                // deliberately so. `ConfigManager` owns the *config* store
+                // only; the categories live in the task store, which is opened
+                // from `storage.type`/`storage.path` - config values this very
+                // method may be in the middle of changing. Validating here
+                // would mean opening (and creating) task storage as a side
+                // effect of `config set`, which is the one command that today
+                // never touches it (see `main::open_storage`).
+                //
+                // Validation would also be worth less than it looks:
+                // categories can be deleted after the fact, so a check here
+                // could never make the value trustworthy at the point of use.
+                // `main::resolve_add_category` therefore resolves it - and
+                // reports it as an error - when `add` actually falls through
+                // to it (issue #33).
                 config.default_category = Some(value.to_string());
             }
             "default-priority" => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,9 +14,6 @@ pub enum ConfigError {
     InvalidConfig(String),
     #[error("Storage error: {0}")]
     Storage(String),
-    #[error("Migration error: {0}")]
-    #[allow(dead_code)]
-    Migration(String),
     #[error("Invalid key: {0}")]
     InvalidKey(String),
 }
@@ -234,7 +231,6 @@ fn default_priority() -> Option<String> {
 
 pub struct ConfigManager {
     storage: Box<dyn Storage>,
-    old_storage_type: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -253,10 +249,7 @@ impl ConfigManager {
             ConfigStorage::new(&config_path).map_err(|e| ConfigError::Storage(e.to_string()))?;
         let storage = Box::new(storage);
 
-        Ok(Self {
-            storage,
-            old_storage_type: None,
-        })
+        Ok(Self { storage })
     }
 
     pub fn save(&self) -> Result<(), ConfigError> {
@@ -302,12 +295,21 @@ impl ConfigManager {
                 let value = validate_lifespan(value)?;
                 config.deleted_task_lifespan = Some(value);
             }
+            // Note what is deliberately *not* here: this used to also print
+            // "Warning: Changing storage type may require data migration" on
+            // every single `set`, and stash the outgoing value in an
+            // `old_storage_type` field feeding `needs_migration()` /
+            // `get_migration_info()` that nothing ever called. The warning
+            // named a migration that did not exist, fired even when there was
+            // no data to migrate, and told the user nothing they could act on
+            // (issue #17). Moving the data is now a real, tested step
+            // (`main::carry_data_across_backend_switch`), and it runs *before*
+            // this method so a failure leaves the setting - and therefore the
+            // user's view of their data - unchanged. Anything it needs to say
+            // about the switch, it says itself and accurately.
             "storage.type" => {
                 validate_storage_type(value)?;
-                // Store old storage type for potential migration
-                self.old_storage_type = Some(config.storage_type.clone().unwrap_or_default());
                 config.storage_type = Some(value.to_string());
-                eprintln!("Warning: Changing storage type may require data migration");
             }
             "storage.path" => {
                 let path = validate_storage_path(value)?;
@@ -402,34 +404,6 @@ impl ConfigManager {
                 stored.default_priority.is_none(),
             ),
         ]
-    }
-
-    #[allow(dead_code)]
-    pub fn needs_migration(&self) -> bool {
-        self.old_storage_type.is_some()
-            && self.old_storage_type.as_ref()
-                != Some(
-                    &self
-                        .stored_config()
-                        .storage_type
-                        .as_ref()
-                        .cloned()
-                        .unwrap_or_default(),
-                )
-    }
-
-    #[allow(dead_code)]
-    pub fn get_migration_info(&self) -> Option<(String, String)> {
-        self.old_storage_type.as_ref().map(|old_type| {
-            (
-                old_type.clone(),
-                self.stored_config()
-                    .storage_type
-                    .as_ref()
-                    .cloned()
-                    .unwrap_or_default(),
-            )
-        })
     }
 
     /// The raw, on-disk config: `None` fields are genuinely unset.

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,7 +131,7 @@ pub struct Config {
     pub default_category: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_priority: Option<String>,
-    /// The first-run marker for issue #27: `Some(true)` records that the
+    /// The first-run marker: `Some(true)` records that the
     /// offer to create the default "Home"/"Work" categories has already been
     /// resolved (accepted, declined, or found unnecessary because categories
     /// already existed), so it is never made a second time.
@@ -157,9 +157,9 @@ impl Config {
     /// be populated with resolved defaults.
     ///
     /// Deliberately distinct from `Config::default()`: collapsing "unset"
-    /// and "documented default" into one value is exactly the bug in issue
-    /// #22 (it makes `config list` unable to tell "you set this" from "this
-    /// is a fallback").
+    /// and "documented default" into one value is a bug that has bitten
+    /// this code before (it makes `config list` unable to tell "you set
+    /// this" from "this is a fallback").
     pub fn unset() -> Self {
         Self {
             deleted_task_lifespan: None,
@@ -172,7 +172,7 @@ impl Config {
     }
 
     /// Whether the first-run offer of the default "Home"/"Work" categories
-    /// has already been resolved and must not be made again (issue #27).
+    /// has already been resolved and must not be made again.
     ///
     /// Anything other than a stored `true` - the key absent (a genuinely
     /// fresh install), or an explicit `false` - means "not yet offered".
@@ -315,7 +315,7 @@ impl ConfigManager {
     }
 
     /// Whether the first-run offer of the default "Home"/"Work" categories
-    /// has already been resolved (issue #27).
+    /// has already been resolved.
     ///
     /// Reads the *stored* config, never the effective one: the point of the
     /// marker is to distinguish "nothing has ever been written here" from
@@ -362,8 +362,8 @@ impl ConfigManager {
             // `old_storage_type` field feeding `needs_migration()` /
             // `get_migration_info()` that nothing ever called. The warning
             // named a migration that did not exist, fired even when there was
-            // no data to migrate, and told the user nothing they could act on
-            // (issue #17). Moving the data is now a real, tested step
+            // no data to migrate, and told the user nothing they could act
+            // on. Moving the data is now a real, tested step
             // (`main::carry_data_across_backend_switch`), and it runs *before*
             // this method so a failure leaves the setting - and therefore the
             // user's view of their data - unchanged. Anything it needs to say
@@ -391,7 +391,7 @@ impl ConfigManager {
                 // could never make the value trustworthy at the point of use.
                 // `main::resolve_add_category` therefore resolves it - and
                 // reports it as an error - when `add` actually falls through
-                // to it (issue #33).
+                // to it.
                 config.default_category = Some(value.to_string());
             }
             "default-priority" => {
@@ -534,7 +534,7 @@ mod tests {
     }
 
     // Previously asserted `None` for every key on a fresh config file - that
-    // encoded the issue #22 bug (documented defaults were never applied).
+    // encoded the bug where documented defaults were never applied.
     // `ConfigManager::get` returns the *effective* value, so a fresh install
     // must report the README's documented defaults, not `None`.
     // `default-category` has no documented default, so `None` there is
@@ -552,8 +552,8 @@ mod tests {
 
     // Previously only asserted that every key reports as a default (still
     // true - nothing has been set), but not *what* the printed value is,
-    // which is exactly what issue #22 got wrong (the value was `null`
-    // instead of the documented default).
+    // which is exactly what the earlier implementation got wrong (the value
+    // was `null` instead of the documented default).
     #[test]
     fn test_config_manager_list() {
         let temp_file = NamedTempFile::new().unwrap();
@@ -570,7 +570,7 @@ mod tests {
         assert_eq!(value_of("default-priority"), "medium");
     }
 
-    /// Regression test for issue #22's second, easier-to-miss half: once
+    /// Regression test for the second, easier-to-miss half of that bug: once
     /// *any* key has been `set`, the config file exists and every other key
     /// must still report as a default on the next load - not as an explicit
     /// `null` that beats the `#[serde(default)]` helper. A bare `impl
@@ -609,7 +609,7 @@ mod tests {
 
     /// `Config::default()` (the documented, *effective* defaults) and
     /// `Config::unset()` (nothing stored yet) must never collapse into the
-    /// same value - doing so is exactly the bug in issue #22.
+    /// same value - doing so is exactly the bug described on `unset`.
     #[test]
     fn test_default_and_unset_are_distinct() {
         let defaults = Config::default();
@@ -626,7 +626,7 @@ mod tests {
         assert_eq!(unset.default_priority, None);
     }
 
-    /// Issue #27: a fresh config (nothing stored) must report the first-run
+    /// A fresh config (nothing stored) must report the first-run
     /// offer as *not* made, and recording it must survive into the next
     /// process invocation - that persistence is the whole mechanism that
     /// stops the offer being repeated.

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,6 +131,20 @@ pub struct Config {
     pub default_category: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_priority: Option<String>,
+    /// The first-run marker for issue #27: `Some(true)` records that the
+    /// offer to create the default "Home"/"Work" categories has already been
+    /// resolved (accepted, declined, or found unnecessary because categories
+    /// already existed), so it is never made a second time.
+    ///
+    /// This is bookkeeping, not a preference, so it is deliberately absent
+    /// from `ConfigManager::{get, set, unset, list}` and from the README's
+    /// configuration table: `config list` stays a faithful rendering of that
+    /// table, and there is no user-facing key whose meaning we would have to
+    /// define. It is still plain JSON in the same file, so anyone who wants
+    /// the offer back can delete the line (or set it to `false`, which reads
+    /// as "not yet offered" - see `Config::default_categories_offered`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_categories_offered: Option<bool>,
 }
 
 impl Config {
@@ -153,7 +167,17 @@ impl Config {
             storage_path: None,
             default_category: None,
             default_priority: None,
+            default_categories_offered: None,
         }
+    }
+
+    /// Whether the first-run offer of the default "Home"/"Work" categories
+    /// has already been resolved and must not be made again (issue #27).
+    ///
+    /// Anything other than a stored `true` - the key absent (a genuinely
+    /// fresh install), or an explicit `false` - means "not yet offered".
+    pub fn default_categories_offered(&self) -> bool {
+        self.default_categories_offered.unwrap_or(false)
     }
 
     /// Resolves every unset field to its documented default, leaving any
@@ -170,6 +194,9 @@ impl Config {
             storage_path: self.storage_path.clone().or(defaults.storage_path),
             default_category: self.default_category.clone().or(defaults.default_category),
             default_priority: self.default_priority.clone().or(defaults.default_priority),
+            // Not a documented setting with a default value - "unset" is the
+            // whole signal here, so it is carried through untouched.
+            default_categories_offered: self.default_categories_offered,
         }
     }
 
@@ -200,6 +227,10 @@ impl Default for Config {
             // `default-category` has no documented default (README: `null`).
             default_category: None,
             default_priority: default_priority(),
+            // Not a user-facing setting: an unset marker means "the first-run
+            // offer hasn't been made yet", which is exactly right for a
+            // fresh install.
+            default_categories_offered: None,
         }
     }
 }
@@ -281,6 +312,36 @@ impl ConfigManager {
             "default-priority" => config.default_priority.map(|v| v.to_string()),
             _ => None,
         }
+    }
+
+    /// Whether the first-run offer of the default "Home"/"Work" categories
+    /// has already been resolved (issue #27).
+    ///
+    /// Reads the *stored* config, never the effective one: the point of the
+    /// marker is to distinguish "nothing has ever been written here" from
+    /// "the user answered", and resolving it through defaults would erase
+    /// exactly that distinction.
+    pub fn default_categories_offered(&self) -> bool {
+        self.stored_config().default_categories_offered()
+    }
+
+    /// Records that the first-run offer has been resolved, so no later run
+    /// makes it again - including after the user deliberately deletes every
+    /// category, which is a legitimate empty state and not a fresh install.
+    ///
+    /// Deliberately not reachable through `set`: this is bookkeeping rather
+    /// than a documented configuration key (see `Config`).
+    pub fn record_default_categories_offer(&mut self) -> Result<(), ConfigError> {
+        // Load-mutate-save, like `set`, so any keys the user has already
+        // stored survive.
+        let mut data = self
+            .storage
+            .load()
+            .map_err(|e| ConfigError::Storage(e.to_string()))?;
+        data.config.default_categories_offered = Some(true);
+        self.storage
+            .save(&data)
+            .map_err(|e| ConfigError::Storage(e.to_string()))
     }
 
     pub fn set(&mut self, key: &str, value: &str) -> Result<(), ConfigError> {
@@ -563,5 +624,71 @@ mod tests {
         assert_eq!(unset.storage_path, None);
         assert_eq!(unset.default_category, None);
         assert_eq!(unset.default_priority, None);
+    }
+
+    /// Issue #27: a fresh config (nothing stored) must report the first-run
+    /// offer as *not* made, and recording it must survive into the next
+    /// process invocation - that persistence is the whole mechanism that
+    /// stops the offer being repeated.
+    #[test]
+    fn test_default_categories_offer_marker_persists() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.json");
+
+        let mut manager = ConfigManager::new(Some(&config_path)).unwrap();
+        assert!(!manager.default_categories_offered());
+        assert!(
+            !config_path.exists(),
+            "merely asking must not create the config file"
+        );
+
+        manager.record_default_categories_offer().unwrap();
+        assert!(manager.default_categories_offered());
+
+        let manager = ConfigManager::new(Some(&config_path)).unwrap();
+        assert!(manager.default_categories_offered());
+    }
+
+    /// The marker is bookkeeping, not a documented setting: it must not
+    /// appear in `config list` (which mirrors the README's configuration
+    /// table) and must not be reachable through `set` / `default`.
+    #[test]
+    fn test_default_categories_offer_marker_is_not_a_user_facing_key() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.json");
+
+        let mut manager = ConfigManager::new(Some(&config_path)).unwrap();
+        manager.record_default_categories_offer().unwrap();
+
+        let list = manager.list();
+        assert_eq!(list.len(), 5);
+        assert!(!list
+            .iter()
+            .any(|(key, _, _)| key.contains("default-categories")));
+        assert_eq!(manager.get("default-categories-offered"), None);
+        assert!(manager.set("default-categories-offered", "false").is_err());
+        assert!(manager.unset("default-categories-offered").is_err());
+    }
+
+    /// Recording the marker must not disturb settings the user already
+    /// stored, and setting a key afterwards must not wipe the marker - both
+    /// halves of the load-mutate-save round trip.
+    #[test]
+    fn test_recording_the_marker_preserves_other_keys_and_vice_versa() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.json");
+
+        let mut manager = ConfigManager::new(Some(&config_path)).unwrap();
+        manager.set("default-priority", "high").unwrap();
+        manager.record_default_categories_offer().unwrap();
+        assert_eq!(manager.get("default-priority"), Some("high".to_string()));
+
+        manager.set("deleted-task-lifespan", "7").unwrap();
+        assert!(manager.default_categories_offered());
+
+        let manager = ConfigManager::new(Some(&config_path)).unwrap();
+        assert!(manager.default_categories_offered());
+        assert_eq!(manager.get("default-priority"), Some("high".to_string()));
+        assert_eq!(manager.get("deleted-task-lifespan"), Some("7".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,26 @@ pub enum CliError {
          non-interactively ('deleted list' shows what would be destroyed)"
     )]
     FlushNotConfirmed,
+    /// `default-category` is persisted without ever being checked against the
+    /// category list - `ConfigManager::set` has no access to task storage, and
+    /// even a name that was valid when it was set can be deleted afterwards.
+    /// So `add` can reach step 3 of `resolve_add_category` and find nothing
+    /// there.
+    ///
+    /// This is an error rather than a warning-and-fall-through to
+    /// Uncategorized: the user named a destination for their new tasks, and
+    /// quietly filing one somewhere else is the single outcome they are least
+    /// likely to notice. It is also the consistent choice - an explicit
+    /// `--category NoSuchThing` is already a hard error via
+    /// `resolve_category`, and `default-category` is the same act of naming a
+    /// category, just written down in advance. Erroring costs the user one
+    /// re-run; a misfiled task costs them finding it again.
+    #[error(
+        "config 'default-category' names a category that does not exist: '{0}'; \
+         create it, point 'default-category' at an existing category, or pass \
+         --category explicitly"
+    )]
+    UnresolvableDefaultCategory(String),
 }
 
 fn main() {
@@ -577,6 +597,76 @@ fn resolve_default_priority(config_manager: &ConfigManager) -> Result<Priority, 
     Ok(Priority::from_str(&value)?)
 }
 
+/// Resolves the category a task created by `add` should land in (issue #33).
+///
+/// `add` is the odd one out among the task commands: `Delete`, `Update`,
+/// `Check`, and `Uncheck` can all degrade to an unscoped search (see
+/// `resolve_task_scope`) because they have an existing task to find, but a
+/// *new* task has to be written somewhere definite. So instead of degrading,
+/// `add` walks a strict precedence chain, most specific first:
+///
+/// 1. an explicit `--category`,
+/// 2. the `category use` context, if one has actually been set,
+/// 3. the `default-category` config value,
+/// 4. Uncategorized.
+///
+/// Step 2 outranking step 3 is deliberate. `category use` is a transient,
+/// just-made statement of "I am working in here right now"; `default-category`
+/// is persistent background configuration set once and then forgotten. Letting
+/// the config win would make the README's promise that "when in a category
+/// context, commands that require category specification can omit the
+/// `--category` argument" quietly untrue for `add` alone, and would leave the
+/// user no way to work outside their default without typing `--category` every
+/// time. In the chosen order both settings stay reachable: `category use` to
+/// override the default for a while, `category clear` to fall back to it
+/// again.
+///
+/// Note step 2 checks `has_explicit_category_context` rather than reading
+/// `get_current_category` directly, exactly as `resolve_task_scope` and
+/// `require_category_context` do. `get_current_category` answers
+/// `Some(UNCATEGORIZED_ID)` even when no context was ever set, so using it
+/// here would collapse step 2 into step 4 and make steps 3 and 4 dead code -
+/// `default-category` would go on being ignored, which is the entire bug this
+/// resolves.
+///
+/// Returns an ID rather than a `Category` so a context pointing at a category
+/// that has since vanished prints the same way `list` does (see
+/// `category_display_name`) instead of needing a second failure mode here.
+fn resolve_add_category(
+    category_manager: &CategoryManager,
+    config_manager: &ConfigManager,
+    category: Option<String>,
+) -> Result<u64, CliError> {
+    // 1. An explicit `--category` always wins, and an unresolvable one is an
+    //    error - unchanged behaviour from when this argument was mandatory.
+    if let Some(reference) = category {
+        return Ok(resolve_category(category_manager, &reference)?.id);
+    }
+
+    // 2. The `category use` context, but only if one was really set.
+    if category_manager.has_explicit_category_context() {
+        return Ok(category_manager
+            .get_current_category()
+            .expect("has_explicit_category_context() true implies Some(..)"));
+    }
+
+    // 3. The configured `default-category`. It stores a *name* (or ID) rather
+    //    than a resolved ID on purpose: category IDs are handed back out after
+    //    a delete (issue #16), so a stored ID could silently start pointing at
+    //    an unrelated category, whereas a stored name can only ever fail to
+    //    resolve - a failure we can report. `ConfigManager::get` returns the
+    //    effective value, and `default-category` has no documented default, so
+    //    `None` here genuinely means "the user never set one".
+    if let Some(reference) = config_manager.get("default-category") {
+        return resolve_category(category_manager, &reference)
+            .map(|category| category.id)
+            .map_err(|_| CliError::UnresolvableDefaultCategory(reference));
+    }
+
+    // 4. Nothing said otherwise, so the task is simply uncategorized.
+    Ok(UNCATEGORIZED_ID)
+}
+
 /// Resolves the scope `Delete`, `Update`, `Check`, and `Uncheck` should
 /// search within, per the README: the explicit `--category` if given,
 /// otherwise the current category context if one has been set via `category
@@ -671,15 +761,20 @@ fn run_task_command(
             category,
             priority,
         } => {
-            let category = resolve_category(&category_manager, &category)?;
+            let category_id = resolve_add_category(&category_manager, config_manager, category)?;
             let priority = match priority {
                 Some(p) => to_model_priority(p),
                 None => resolve_default_priority(config_manager)?,
             };
-            let id = task_manager.add_task(title.clone(), category.id, priority, None)?;
+            let id = task_manager.add_task(title.clone(), category_id, priority, None)?;
+            // Always name the category that was actually used, even when the
+            // user did not: with `--category` now optional, the confirmation
+            // line is how they find out which of the four resolution steps
+            // won.
+            let category_name = category_display_name(&category_manager, category_id)?;
             println!(
                 "Task '{}' added with ID {} in category '{}'",
-                title, id, category.name
+                title, id, category_name
             );
         }
         Commands::Delete {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 use cli::{CategoryCommands, Cli, Commands, ConfigCommands, DeletedCommands};
 use config::{ConfigError, ConfigManager};
 use models::{Category, CategoryError, Priority, PriorityError, StorageError, Task};
-use prompter::{PromptError, StdinPrompter};
+use prompter::{NonInteractivePrompter, PromptError, Prompter, StdinPrompter};
 use std::path::PathBuf;
 use storage::{create_storage, migrate_storage, MigrationOutcome, Storage, StorageType};
 use task_manager::{confirm_flush, TaskManager, TaskManagerError};
@@ -116,6 +116,11 @@ fn run() -> Result<(), CliError> {
     // override so callers (and tests) can point at a config file outside $HOME.
     let mut config_manager = ConfigManager::new(cli.config.as_deref())?;
 
+    // One prompter for the whole invocation, chosen from the non-interactive
+    // flags. Built here rather than inside each command so `--yes` /
+    // `--no-input` mean the same thing everywhere.
+    let mut prompter = build_prompter(&cli);
+
     match cli.command {
         Commands::Config { command } => match command {
             ConfigCommands::Set { key_value } => {
@@ -143,19 +148,130 @@ fn run() -> Result<(), CliError> {
             }
         },
         Commands::Category { command } => {
-            let storage = open_storage(&config_manager)?;
+            let storage = open_task_storage(&mut config_manager, prompter.as_mut())?;
             run_category_command(&*storage, command)?;
         }
         Commands::Deleted { command } => {
-            let storage = open_storage(&config_manager)?;
+            let storage = open_task_storage(&mut config_manager, prompter.as_mut())?;
             run_deleted_command(&*storage, command)?;
         }
         other => {
-            let storage = open_storage(&config_manager)?;
-            run_task_command(&*storage, &config_manager, other)?;
+            let storage = open_task_storage(&mut config_manager, prompter.as_mut())?;
+            run_task_command(&*storage, &config_manager, prompter.as_mut(), other)?;
         }
     }
 
+    Ok(())
+}
+
+/// Picks the prompter for this invocation.
+///
+/// With neither flag the real `StdinPrompter` is used - which is still safe
+/// for automation, because it detects a non-interactive stdin itself and
+/// reports `PromptError::NotInteractive` rather than blocking on a
+/// `read_line` nobody will answer.
+fn build_prompter(cli: &Cli) -> Box<dyn Prompter> {
+    if cli.yes {
+        Box::new(NonInteractivePrompter::assuming_yes())
+    } else if cli.no_input {
+        Box::new(NonInteractivePrompter::assuming_no())
+    } else {
+        Box::new(StdinPrompter)
+    }
+}
+
+/// The categories a first run offers to create, in the order they get
+/// created (README: "offer to create the default categories of 'Home' and
+/// 'Work'").
+const DEFAULT_CATEGORIES: [&str; 2] = ["Home", "Work"];
+
+/// Opens task storage for a command that needs it, making the first-run
+/// offer (issue #27) on the way.
+///
+/// This is the *only* path to task storage from `run`, which is what decides
+/// the answer to "which commands trigger the offer?": every command that
+/// touches tasks or categories does, and `trtodo config ...` - the one
+/// command group that never opens task storage - does not. That is
+/// deliberate:
+///
+///   - creating categories means writing the data file, so offering during
+///     `config list` would turn a read-only query into a storage mutation
+///     (and into a `create_dir_all`, see `open_storage`);
+///   - `config set storage.path=...` is exactly how a user says where their
+///     data should live, and prompting *before* that took effect would
+///     create the default categories in the location they were in the middle
+///     of changing;
+///   - `--help` / `--version` never reach `run` at all, since clap exits
+///     first, so they can't prompt either way.
+///
+/// The trade-off is that a user whose very first command is `config list`
+/// gets the offer on their next real command instead - which is the right
+/// time for it anyway.
+fn open_task_storage(
+    config_manager: &mut ConfigManager,
+    prompter: &mut dyn Prompter,
+) -> Result<Box<dyn Storage>, CliError> {
+    let storage = open_storage(config_manager)?;
+    offer_default_categories(&*storage, config_manager, prompter)?;
+    Ok(storage)
+}
+
+/// Offers to create the README's default "Home" and "Work" categories the
+/// first time `trtodo` touches task storage (issue #27, closing out issue
+/// #4).
+///
+/// "First run" is a *config* fact, not a storage fact: the marker written by
+/// `ConfigManager::record_default_categories_offer` records that the offer
+/// has been resolved. Deciding from storage alone ("are there no categories?")
+/// would re-offer forever to anyone who deliberately deleted every category,
+/// and an earlier attempt at this feature was rejected for a related pair of
+/// mistakes - creating the categories outright rather than offering, and
+/// doing it on every invocation rather than once.
+///
+/// The offer is skipped, and the marker recorded silently, when categories
+/// already exist: that is an established install (or one upgrading from a
+/// version predating this feature), not a fresh one, and it must not be
+/// interrupted to be asked about categories it clearly doesn't need.
+///
+/// A `PromptError` is *not* an answer, so it records nothing and prints
+/// nothing: with no terminal attached (a pipe, a cron job, CI) there is
+/// nobody to ask, and the run must neither block nor quietly burn the
+/// one-and-only offer that a human would have wanted to see. Automation that
+/// wants a definite answer passes `--yes` or `--no-input`.
+fn offer_default_categories(
+    storage: &dyn Storage,
+    config_manager: &mut ConfigManager,
+    prompter: &mut dyn Prompter,
+) -> Result<(), CliError> {
+    if config_manager.default_categories_offered() {
+        return Ok(());
+    }
+
+    if !storage.get_all_categories()?.is_empty() {
+        config_manager.record_default_categories_offer()?;
+        return Ok(());
+    }
+
+    let question = format!(
+        "It looks like this is your first run. Create the default categories {}?",
+        DEFAULT_CATEGORIES.join(" and ")
+    );
+    let accepted = match prompter.confirm(&question, true) {
+        Ok(accepted) => accepted,
+        Err(_) => return Ok(()),
+    };
+
+    if accepted {
+        let mut category_manager = CategoryManager::new(storage);
+        for name in DEFAULT_CATEGORIES {
+            let id = category_manager.add_category(name.to_string(), None)?;
+            println!("Category '{}' added with ID {}", name, id);
+        }
+    } else {
+        println!("Skipped; add categories yourself with 'trtodo category add <name>'");
+    }
+
+    config_manager.record_default_categories_offer()?;
     Ok(())
 }
 
@@ -744,16 +860,16 @@ fn category_display_name(
 fn run_task_command(
     storage: &dyn Storage,
     config_manager: &ConfigManager,
+    // The invocation's prompter (see `build_prompter`). Its `choose` detects
+    // a non-interactive stdin (e.g. this binary run from a test harness or a
+    // script) and returns a clean `PromptError::NotInteractive` instead of
+    // blocking - see `crate::prompter` for why this is a trait rather than an
+    // inline `stdin().read_line()` call.
+    prompter: &mut dyn Prompter,
     command: Commands,
 ) -> Result<(), CliError> {
     let category_manager = CategoryManager::new(storage);
     let task_manager = TaskManager::new(storage);
-    // The real, interactive prompter. Its `choose` detects a non-interactive
-    // stdin (e.g. this binary run from a test harness or a script) and
-    // returns a clean `PromptError::NotInteractive` instead of blocking -
-    // see `crate::prompter` for why this is a trait rather than an inline
-    // `stdin().read_line()` call.
-    let mut prompter = StdinPrompter;
 
     match command {
         Commands::Add {
@@ -782,7 +898,7 @@ fn run_task_command(
             category,
         } => {
             let scope = resolve_task_scope(&category_manager, category)?;
-            let task = task_manager.resolve_task(&title_or_id, scope, &mut prompter)?;
+            let task = task_manager.resolve_task(&title_or_id, scope, prompter)?;
             task_manager.delete_task(task.id)?;
             println!("Task '{}' deleted", task.title);
         }
@@ -792,7 +908,7 @@ fn run_task_command(
             category,
         } => {
             let scope = resolve_task_scope(&category_manager, category)?;
-            let task = task_manager.resolve_task(&title_or_id, scope, &mut prompter)?;
+            let task = task_manager.resolve_task(&title_or_id, scope, prompter)?;
             let old_title = task.title.clone();
             task_manager.rename_task(task, new_title.clone())?;
             println!("Task '{}' renamed to '{}'", old_title, new_title);
@@ -802,7 +918,7 @@ fn run_task_command(
             category,
         } => {
             let scope = resolve_task_scope(&category_manager, category)?;
-            let task = task_manager.resolve_task(&title_or_id, scope, &mut prompter)?;
+            let task = task_manager.resolve_task(&title_or_id, scope, prompter)?;
             let title = task.title.clone();
             task_manager.set_completed(task, true)?;
             println!("Task '{}' checked off", title);
@@ -812,7 +928,7 @@ fn run_task_command(
             category,
         } => {
             let scope = resolve_task_scope(&category_manager, category)?;
-            let task = task_manager.resolve_task(&title_or_id, scope, &mut prompter)?;
+            let task = task_manager.resolve_task(&title_or_id, scope, prompter)?;
             let title = task.title.clone();
             task_manager.set_completed(task, false)?;
             println!("Task '{}' unchecked", title);
@@ -858,8 +974,7 @@ fn run_task_command(
                     _ => return Err(CliError::InvalidMoveArguments),
                 };
 
-            let task =
-                task_manager.resolve_task(&task_ref, Some(scope_category_id), &mut prompter)?;
+            let task = task_manager.resolve_task(&task_ref, Some(scope_category_id), prompter)?;
             task_manager.move_task(task.id, target_category_id)?;
             let target_name = category_display_name(&category_manager, target_category_id)?;
             println!("Task '{}' moved to '{}'", task.title, target_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,11 @@ use category_manager::{CategoryManager, UNCATEGORIZED_ID};
 use clap::Parser;
 use cli::{CategoryCommands, Cli, Commands, ConfigCommands, DeletedCommands};
 use config::{ConfigError, ConfigManager};
-use models::{Category, CategoryError, Priority, PriorityError, StorageError};
-use prompter::StdinPrompter;
+use models::{Category, CategoryError, Priority, PriorityError, StorageError, Task};
+use prompter::{PromptError, StdinPrompter};
 use std::path::PathBuf;
 use storage::{create_storage, migrate_storage, MigrationOutcome, Storage, StorageType};
-use task_manager::{TaskManager, TaskManagerError};
+use task_manager::{confirm_flush, TaskManager, TaskManagerError};
 use thiserror::Error;
 
 /// Top-level application error type.
@@ -63,6 +63,23 @@ pub enum CliError {
          to Uncategorized)"
     )]
     InvalidMoveArguments,
+    /// `deleted flush` is the only irreversible command in the CLI, so it
+    /// asks first (issue #32). When there is no terminal to ask at -
+    /// `StdinPrompter` detects that and returns `PromptError::NotInteractive`
+    /// rather than blocking - the choice is between destroying the data
+    /// unattended and refusing. It refuses: a script that meant to flush can
+    /// say so with `--yes`, whereas a script that flushed by accident has no
+    /// way to say it didn't mean it.
+    ///
+    /// `PromptError::NotInteractive`'s own message is not reused here; it
+    /// talks about picking between multiple matches and offers `--category`,
+    /// neither of which applies to a flush.
+    #[error(
+        "'deleted flush' permanently destroys every soft-deleted task, and there is no \
+         terminal attached to confirm at; re-run interactively, or pass --yes to confirm \
+         non-interactively ('deleted list' shows what would be destroyed)"
+    )]
+    FlushNotConfirmed,
 }
 
 fn main() {
@@ -405,17 +422,119 @@ fn run_category_command(storage: &dyn Storage, command: CategoryCommands) -> Res
 }
 
 /// Dispatches `trtodo deleted ...`. Mirrors `run_category_command`'s shape.
+///
+/// Unlike that function this also needs a `CategoryManager`: soft-deleted
+/// tasks keep their real `category_id` (issue #29), and both `list` and
+/// `restore` are only useful if that is reported as a *name* the user
+/// recognizes rather than a bare number.
 fn run_deleted_command(storage: &dyn Storage, command: DeletedCommands) -> Result<(), CliError> {
+    let category_manager = CategoryManager::new(storage);
     let task_manager = TaskManager::new(storage);
+    // See `run_task_command` for why this is the `Prompter` seam and not an
+    // inline `stdin().read_line()`.
+    let mut prompter = StdinPrompter;
 
     match command {
-        DeletedCommands::Flush => {
-            let count = task_manager.flush_deleted()?;
-            println!("Flushed {} deleted task(s)", count);
+        DeletedCommands::List => {
+            let tasks = task_manager.list_deleted()?;
+            println!("Deleted tasks:");
+            // `list` prints its header and then nothing when there is
+            // nothing to show, which is fine for a command whose answer is
+            // "you have no tasks". This command's whole job is to answer
+            // "what would a flush destroy?", and silence is a bad way to say
+            // "nothing" - it is indistinguishable from a command that failed
+            // to look.
+            if tasks.is_empty() {
+                println!("  (none)");
+            }
+            for task in &tasks {
+                println!("{}", format_deleted_task(&category_manager, task)?);
+            }
+        }
+        DeletedCommands::Restore { title_or_id } => {
+            let task = task_manager.resolve_deleted_task(&title_or_id, &mut prompter)?;
+            let title = task.title.clone();
+            let original_category_id = task.category_id;
+            let category_id = task_manager.restore_task(task)?;
+            let category_name = category_display_name(&category_manager, category_id)?;
+            if category_id == original_category_id {
+                println!("Task '{}' restored to category '{}'", title, category_name);
+            } else {
+                // Only reachable from externally-edited data - see
+                // `task_manager::restore_destination` - but if it ever
+                // happens the user should hear that the task did not go back
+                // where it came from.
+                println!(
+                    "Task '{}' restored to category '{}'; its original category no longer exists",
+                    title, category_name
+                );
+            }
+        }
+        DeletedCommands::Flush { yes } => {
+            let pending = task_manager.list_deleted()?;
+
+            // Nothing at stake means nothing to confirm: a flush with an
+            // empty deleted set is a documented no-op, and prompting for
+            // permission to destroy zero tasks (or failing a script over it)
+            // would be noise.
+            if pending.is_empty() {
+                println!("Flushed 0 deleted task(s)");
+                return Ok(());
+            }
+
+            // Printed before the flush in both paths, so it serves as the
+            // confirmation preview *and* as the record of what was destroyed
+            // (issue #32 asked for both; one listing satisfies both, and
+            // printing it afterwards instead would mean the interactive user
+            // confirms blind).
+            println!(
+                "The following {} task(s) will be permanently removed:",
+                pending.len()
+            );
+            for task in &pending {
+                println!("{}", format_deleted_task(&category_manager, task)?);
+            }
+
+            if !yes {
+                match confirm_flush(&mut prompter, pending.len()) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        println!("Flush cancelled; nothing was removed");
+                        return Ok(());
+                    }
+                    Err(PromptError::NotInteractive) => return Err(CliError::FlushNotConfirmed),
+                    Err(e) => return Err(TaskManagerError::from(e).into()),
+                }
+            }
+
+            let flushed = task_manager.flush_deleted()?;
+            println!("Flushed {} deleted task(s)", flushed.len());
         }
     }
 
     Ok(())
+}
+
+/// One row of `deleted list`: ID, title, the task's *real* category name,
+/// and when it was deleted (issue #32's four columns).
+///
+/// Shared with `flush`'s preview so the two commands describe the same task
+/// in exactly the same words. Formatted after `run_task_command`'s `list`
+/// (`<id>: <title> (...)`), minus the `[x]` completion marker: whether a
+/// task about to be destroyed was ticked off first is not information
+/// anybody is deciding on.
+fn format_deleted_task(
+    category_manager: &CategoryManager,
+    task: &Task,
+) -> Result<String, CliError> {
+    let category_name = category_display_name(category_manager, task.category_id)?;
+    Ok(format!(
+        "{}: {} (category: {}, deleted: {})",
+        task.id,
+        task.title,
+        category_name,
+        task.deleted_at_display()
+    ))
 }
 
 /// Resolves a user-supplied category reference, which the README allows to be

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use config::{ConfigError, ConfigManager};
 use models::{Category, CategoryError, Priority, PriorityError, StorageError};
 use prompter::StdinPrompter;
 use std::path::PathBuf;
-use storage::{create_storage, Storage, StorageType};
+use storage::{create_storage, migrate_storage, MigrationOutcome, Storage, StorageType};
 use task_manager::{TaskManager, TaskManagerError};
 use thiserror::Error;
 
@@ -85,6 +85,12 @@ fn run() -> Result<(), CliError> {
                 let (key, value) = key_value
                     .split_once('=')
                     .ok_or_else(|| CliError::MalformedKeyValue(key_value.clone()))?;
+                // Deliberately *before* the config is written: if carrying the
+                // user's data across fails, the setting stays where it was and
+                // they are still looking at their tasks (issue #17).
+                if key == "storage.type" {
+                    carry_data_across_backend_switch(&config_manager, value)?;
+                }
                 config_manager.set(key, value)?;
                 println!("Configuration updated successfully");
             }
@@ -133,33 +139,174 @@ fn run() -> Result<(), CliError> {
 /// documented default threshold is 0 ("never"), and `purge_deleted_tasks`
 /// itself short-circuits before touching disk in that case.
 fn open_storage(config_manager: &ConfigManager) -> Result<Box<dyn Storage>, CliError> {
-    let storage_type = match config_manager.get("storage.type").as_deref() {
-        None | Some("json") => StorageType::Json,
-        Some("sqlite") => StorageType::Sqlite,
-        Some(other) => return Err(CliError::UnknownStorageType(other.to_string())),
-    };
+    let storage_type = configured_storage_type(config_manager)?;
+    let storage = open_storage_of_type(config_manager, storage_type)?;
+    purge_expired_deleted_tasks(&*storage, config_manager)?;
 
-    let dir = match config_manager.get("storage.path") {
-        Some(path) => PathBuf::from(shellexpand::tilde(&path).as_ref()),
-        None => dirs::home_dir()
+    Ok(storage)
+}
+
+/// The backend named by `storage.type`. `ConfigManager::get` already resolves
+/// the documented default (`json`), so `None` here only happens if that
+/// default ever goes missing - treated the same as any other unrecognised
+/// value rather than silently assumed.
+fn configured_storage_type(config_manager: &ConfigManager) -> Result<StorageType, CliError> {
+    let value = config_manager
+        .get("storage.type")
+        .unwrap_or_else(|| "json".to_string());
+    StorageType::parse(&value).ok_or(CliError::UnknownStorageType(value))
+}
+
+/// The `storage.path` *directory* every backend keeps its data file in. See
+/// `StorageType::data_file_name` for why the file name varies by backend.
+fn storage_dir(config_manager: &ConfigManager) -> Result<PathBuf, CliError> {
+    match config_manager.get("storage.path") {
+        Some(path) => Ok(PathBuf::from(shellexpand::tilde(&path).as_ref())),
+        None => Ok(dirs::home_dir()
             .ok_or(CliError::NoHomeDirectory)?
             .join(".config")
-            .join("trtodo"),
-    };
+            .join("trtodo")),
+    }
+}
 
-    let file_name = match storage_type {
-        StorageType::Json => "trtodo-data.json",
-        StorageType::Sqlite => "trtodo-data.db",
-    };
+/// Opens a *specific* backend against the configured storage directory,
+/// without the automatic purge sweep.
+///
+/// `open_storage` is the entry point for commands, which want the configured
+/// backend and want the sweep to run. This one exists for
+/// `carry_data_across_backend_switch`, which needs to hold both the outgoing
+/// and incoming backends open at once and must not have a purge fire against
+/// a store it is merely reading in passing.
+fn open_storage_of_type(
+    config_manager: &ConfigManager,
+    storage_type: StorageType,
+) -> Result<Box<dyn Storage>, CliError> {
+    let dir = storage_dir(config_manager)?;
 
     // SQLite cannot create the containing directory for us, and JSON only does
     // so on save - make sure it exists before either backend opens the file.
     std::fs::create_dir_all(&dir)?;
 
-    let storage = create_storage(storage_type, &dir.join(file_name))?;
-    purge_expired_deleted_tasks(&*storage, config_manager)?;
+    Ok(create_storage(
+        storage_type,
+        &dir.join(storage_type.data_file_name()),
+    )?)
+}
 
-    Ok(storage)
+/// Carries the user's tasks and categories over when `storage.type` changes,
+/// and reports honestly when it can't (issue #17).
+///
+/// Each backend keeps its own data file, so before this existed a switch made
+/// every category and task disappear from view with nothing but "Warning:
+/// Changing storage type may require data migration" - naming a migration
+/// that did not exist - to explain it. Nothing was actually destroyed (the old
+/// file sat there untouched, and switching back revealed it again), but it
+/// read as data loss, which for a todo list is nearly as bad.
+///
+/// The copy itself is `storage::migrate_storage`, which owns the safety
+/// rules: source is never written to, a non-empty destination is never
+/// overwritten, IDs are never renumbered. All this function does is resolve
+/// the two backends and turn the outcome into something a person can read.
+///
+/// Anything that isn't a real backend change is a silent no-op: setting
+/// `storage.type` to what it already is, or to a value
+/// `ConfigManager::set` is about to reject anyway.
+fn carry_data_across_backend_switch(
+    config_manager: &ConfigManager,
+    new_value: &str,
+) -> Result<(), CliError> {
+    let Some(new_type) = StorageType::parse(new_value) else {
+        // Not a backend we know. Say nothing and let `ConfigManager::set`
+        // produce its own "must be one of: json, sqlite" error.
+        return Ok(());
+    };
+
+    let old_type = configured_storage_type(config_manager)?;
+    if old_type == new_type {
+        return Ok(());
+    }
+
+    let old_file = storage_dir(config_manager)?.join(old_type.data_file_name());
+    if !old_file.exists() {
+        // Nothing was ever written under the outgoing backend - a first-ever
+        // switch. Don't open the new backend just to tell the user nothing
+        // happened.
+        return Ok(());
+    }
+
+    // A source we can't read is the one failure that must NOT block the
+    // switch. If the outgoing store is corrupt, unreadable, or written by a
+    // build we don't understand, then the user can't see that data under the
+    // old backend either - refusing to change `storage.type` would trap them
+    // on the broken backend, and do it while reporting an error about the
+    // backend they were trying to leave. Say what happened, leave the file
+    // alone, and let the switch proceed.
+    //
+    // Failures on the *destination* side are handled the opposite way: they
+    // propagate, so the setting stays put and the user keeps looking at the
+    // store that still works.
+    let source = match open_storage_of_type(config_manager, old_type)
+        .and_then(|source| source.load().map(|_| source).map_err(CliError::from))
+    {
+        Ok(source) => source,
+        Err(e) => {
+            eprintln!(
+                "Warning: could not read the existing {} store at {}, so nothing was migrated: {}",
+                old_type.as_str(),
+                old_file.display(),
+                e
+            );
+            eprintln!(
+                "Warning: the file has been left untouched. Run 'trtodo config set \
+                 storage.type={}' to go back to it.",
+                old_type.as_str()
+            );
+            return Ok(());
+        }
+    };
+    let destination = open_storage_of_type(config_manager, new_type)?;
+
+    match migrate_storage(&*source, &*destination)? {
+        MigrationOutcome::SourceEmpty => {}
+        MigrationOutcome::Migrated { tasks, categories } => {
+            println!(
+                "Migrated {} task(s) and {} categor{} from {} to {} storage.",
+                tasks,
+                categories,
+                if categories == 1 { "y" } else { "ies" },
+                old_type.as_str(),
+                new_type.as_str()
+            );
+            println!(
+                "Your previous {} data was left untouched at {}.",
+                old_type.as_str(),
+                old_file.display()
+            );
+        }
+        MigrationOutcome::DestinationNotEmpty { tasks, categories } => {
+            // Both stores hold real data. Refusing to merge them is the
+            // deliberate choice (see `migrate_storage`); what matters is that
+            // the user is told which data they are about to be looking at and
+            // how to get back to the other set.
+            eprintln!(
+                "Warning: {} storage already holds {} task(s) and {} categor{}, so nothing was \
+                 migrated and nothing was overwritten.",
+                new_type.as_str(),
+                tasks,
+                categories,
+                if categories == 1 { "y" } else { "ies" }
+            );
+            eprintln!(
+                "Warning: your {} data is still intact at {}. Run 'trtodo config set \
+                 storage.type={}' to go back to it.",
+                old_type.as_str(),
+                old_file.display(),
+                old_type.as_str()
+            );
+        }
+    }
+
+    Ok(())
 }
 
 /// Runs the automatic, `deleted-task-lifespan`-gated purge (README: "purged

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ pub enum CliError {
     )]
     InvalidMoveArguments,
     /// `deleted flush` is the only irreversible command in the CLI, so it
-    /// asks first (issue #32). When there is no terminal to ask at -
+    /// asks first. When there is no terminal to ask at -
     /// `StdinPrompter` detects that and returns `PromptError::NotInteractive`
     /// rather than blocking - the choice is between destroying the data
     /// unattended and refusing. It refuses: a script that meant to flush can
@@ -129,7 +129,7 @@ fn run() -> Result<(), CliError> {
                     .ok_or_else(|| CliError::MalformedKeyValue(key_value.clone()))?;
                 // Deliberately *before* the config is written: if carrying the
                 // user's data across fails, the setting stays where it was and
-                // they are still looking at their tasks (issue #17).
+                // they are still looking at their tasks.
                 if key == "storage.type" {
                     carry_data_across_backend_switch(&config_manager, value)?;
                 }
@@ -186,7 +186,7 @@ fn build_prompter(cli: &Cli) -> Box<dyn Prompter> {
 const DEFAULT_CATEGORIES: [&str; 2] = ["Home", "Work"];
 
 /// Opens task storage for a command that needs it, making the first-run
-/// offer (issue #27) on the way.
+/// offer on the way.
 ///
 /// This is the *only* path to task storage from `run`, which is what decides
 /// the answer to "which commands trigger the offer?": every command that
@@ -217,8 +217,7 @@ fn open_task_storage(
 }
 
 /// Offers to create the README's default "Home" and "Work" categories the
-/// first time `trtodo` touches task storage (issue #27, closing out issue
-/// #4).
+/// first time `trtodo` touches task storage.
 ///
 /// "First run" is a *config* fact, not a storage fact: the marker written by
 /// `ConfigManager::record_default_categories_offer` records that the offer
@@ -282,7 +281,7 @@ fn offer_default_categories(
 /// chosen backend.
 ///
 /// Also sweeps up anything overdue for automatic purging under
-/// `deleted-task-lifespan` (issue #6) before handing the storage back. This
+/// `deleted-task-lifespan` before handing the storage back. This
 /// is the one place every command that touches task storage passes through -
 /// `Commands::Config` never calls `open_storage` at all, since it has no
 /// need to touch task storage, so the sweep correctly never runs for it (and
@@ -347,7 +346,7 @@ fn open_storage_of_type(
 }
 
 /// Carries the user's tasks and categories over when `storage.type` changes,
-/// and reports honestly when it can't (issue #17).
+/// and reports honestly when it can't.
 ///
 /// Each backend keeps its own data file, so before this existed a switch made
 /// every category and task disappear from view with nothing but "Warning:
@@ -463,7 +462,7 @@ fn carry_data_across_backend_switch(
 }
 
 /// Runs the automatic, `deleted-task-lifespan`-gated purge (README: "purged
-/// automatically after `deleted-task-lifespan` days"; issue #6) once per
+/// automatically after `deleted-task-lifespan` days") once per
 /// invocation, from within `open_storage`. See that function's doc comment
 /// for why it lives there rather than being duplicated across `run`'s
 /// branches.
@@ -560,7 +559,7 @@ fn run_category_command(storage: &dyn Storage, command: CategoryCommands) -> Res
 /// Dispatches `trtodo deleted ...`. Mirrors `run_category_command`'s shape.
 ///
 /// Unlike that function this also needs a `CategoryManager`: soft-deleted
-/// tasks keep their real `category_id` (issue #29), and both `list` and
+/// tasks keep their real `category_id`, and both `list` and
 /// `restore` are only useful if that is reported as a *name* the user
 /// recognizes rather than a bare number.
 fn run_deleted_command(storage: &dyn Storage, command: DeletedCommands) -> Result<(), CliError> {
@@ -620,9 +619,8 @@ fn run_deleted_command(storage: &dyn Storage, command: DeletedCommands) -> Resul
 
             // Printed before the flush in both paths, so it serves as the
             // confirmation preview *and* as the record of what was destroyed
-            // (issue #32 asked for both; one listing satisfies both, and
-            // printing it afterwards instead would mean the interactive user
-            // confirms blind).
+            // - one listing satisfies both, and printing it afterwards
+            // instead would mean the interactive user confirms blind.
             println!(
                 "The following {} task(s) will be permanently removed:",
                 pending.len()
@@ -652,7 +650,7 @@ fn run_deleted_command(storage: &dyn Storage, command: DeletedCommands) -> Resul
 }
 
 /// One row of `deleted list`: ID, title, the task's *real* category name,
-/// and when it was deleted (issue #32's four columns).
+/// and when it was deleted.
 ///
 /// Shared with `flush`'s preview so the two commands describe the same task
 /// in exactly the same words. Formatted after `run_task_command`'s `list`
@@ -702,10 +700,10 @@ fn to_model_priority(priority: cli::Priority) -> Priority {
     }
 }
 
-/// Resolves the effective `default-priority` config value (issue #22 made
-/// this reliably resolve to the documented default, `medium`, on a fresh
-/// install) to a domain `Priority`, for `add` invocations that omit
-/// `--priority`.
+/// Resolves the effective `default-priority` config value to a domain
+/// `Priority`, for `add` invocations that omit `--priority`. On a fresh
+/// install this resolves to the documented default, `medium`, rather than
+/// to nothing.
 fn resolve_default_priority(config_manager: &ConfigManager) -> Result<Priority, CliError> {
     let value = config_manager
         .get("default-priority")
@@ -713,7 +711,7 @@ fn resolve_default_priority(config_manager: &ConfigManager) -> Result<Priority, 
     Ok(Priority::from_str(&value)?)
 }
 
-/// Resolves the category a task created by `add` should land in (issue #33).
+/// Resolves the category a task created by `add` should land in.
 ///
 /// `add` is the odd one out among the task commands: `Delete`, `Update`,
 /// `Check`, and `Uncheck` can all degrade to an unscoped search (see
@@ -768,7 +766,7 @@ fn resolve_add_category(
 
     // 3. The configured `default-category`. It stores a *name* (or ID) rather
     //    than a resolved ID on purpose: category IDs are handed back out after
-    //    a delete (issue #16), so a stored ID could silently start pointing at
+    //    a delete, so a stored ID could silently start pointing at
     //    an unrelated category, whereas a stored name can only ever fail to
     //    resolve - a failure we can report. `ConfigManager::get` returns the
     //    effective value, and `default-category` has no documented default, so

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -10,7 +10,7 @@ pub struct Task {
     pub description: Option<String>,
     // 0 is the magic "Uncategorized" category ID - see
     // `category_manager::UNCATEGORIZED_ID`. It does NOT mean deleted; deletion
-    // is tracked independently via `deleted_at` below (issue #29).
+    // is tracked independently via `deleted_at` below.
     pub category_id: u64,
     pub completed: bool,
     pub priority: Priority,
@@ -65,7 +65,7 @@ impl Task {
     /// Soft-deletes the task: it is hidden from listings/searches and becomes
     /// eligible for purging (see `Storage::purge_deleted_tasks`), but its
     /// `category_id` is left untouched. Keeping the real category is the
-    /// whole point of this design (issue #29) - it's what makes `restore`
+    /// whole point of this design - it's what makes `restore`
     /// trivial and stops category deletion from ever masquerading as task
     /// deletion.
     pub fn soft_delete(&mut self) {
@@ -75,7 +75,7 @@ impl Task {
 
     /// Un-deletes the task. Because `soft_delete` never touched
     /// `category_id`, this is all a restore takes - the task goes straight
-    /// back where it came from (issue #31). Reachable from the CLI as
+    /// back where it came from. Reachable from the CLI as
     /// `trtodo deleted restore <title or id>`.
     pub fn restore(&mut self) {
         self.deleted_at = None;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -73,9 +73,34 @@ impl Task {
         self.updated_at = Utc::now();
     }
 
+    /// Un-deletes the task. Because `soft_delete` never touched
+    /// `category_id`, this is all a restore takes - the task goes straight
+    /// back where it came from (issue #31). Reachable from the CLI as
+    /// `trtodo deleted restore <title or id>`.
     pub fn restore(&mut self) {
         self.deleted_at = None;
         self.updated_at = Utc::now();
+    }
+
+    /// The deletion timestamp rendered for humans: the "deleted" column of
+    /// `trtodo deleted list`, the flush preview, and the restore
+    /// disambiguation prompt all share this one format so the same task
+    /// looks the same wherever it is shown.
+    ///
+    /// Timestamps are stored in UTC (`Utc::now`), and this deliberately
+    /// prints them as such rather than converting to local time: nothing
+    /// else in the CLI displays a timestamp yet, so there is no local-time
+    /// convention to match, and labelling the zone is better than quietly
+    /// implying one.
+    ///
+    /// A live task has no deletion timestamp; every caller of this today
+    /// works from `Storage::get_deleted_tasks`, so the `None` arm exists
+    /// only so this can never panic on a task that slipped through.
+    pub fn deleted_at_display(&self) -> String {
+        match self.deleted_at {
+            Some(deleted_at) => deleted_at.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+            None => "not deleted".to_string(),
+        }
     }
 
     pub fn mark_completed(&mut self) {

--- a/src/prompter.rs
+++ b/src/prompter.rs
@@ -1,4 +1,4 @@
-//! A seam for interactive "which one did you mean?" prompts.
+//! A seam for interactive prompts.
 //!
 //! The README says: "When operating on a `task_name`, the application will
 //! try to match the name - if it encounters the same name in multiple
@@ -8,19 +8,22 @@
 //! a test that exercises the disambiguation flow without a real terminal
 //! attached - that PR was rejected for exactly this reason.
 //!
-//! `Prompter` factors the "ask the user to choose one of several options"
-//! step behind a trait, so:
+//! `Prompter` factors "ask the user something" behind a trait, so:
 //!   - production code uses `StdinPrompter`, which reads real input but
 //!     detects the non-interactive case (piped/redirected stdin, CI, no TTY)
 //!     up front and returns a typed `PromptError` instead of blocking
 //!     forever on a `read_line` that will never receive input;
+//!   - `--yes` / `--no-input` swap in `NonInteractivePrompter`, which answers
+//!     confirmations from a fixed policy and never reads stdin at all;
 //!   - tests use `ScriptedPrompter`, which replays a pre-programmed sequence
 //!     of answers with no terminal involved at all.
 //!
-//! This is deliberately generic (`choose` over a list of string labels)
-//! rather than task-specific: issue #27 and the deferred `reset` command are
-//! expected to need this exact same "pick one of several matches" flow, so
-//! it is built once here rather than re-invented per feature.
+//! Two questions are modelled, both deliberately generic rather than
+//! feature-specific:
+//!   - `choose`, "pick one of these labelled options" (the ambiguous-task
+//!     flow above, and the deferred `reset` command);
+//!   - `confirm`, "yes or no?" (the first-run offer to create the default
+//!     "Home"/"Work" categories, issue #27).
 
 use std::io::{self, BufRead, IsTerminal, Write};
 use thiserror::Error;
@@ -31,6 +34,11 @@ pub enum PromptError {
     /// non-interactive script, ...). Rather than block forever on a
     /// `read_line` nobody will ever answer, callers surface this as a clean
     /// instruction to disambiguate a different way (e.g. `--category`).
+    ///
+    /// The message below is worded for `choose`, because that is the only
+    /// caller that reports it to the user: the first-run `confirm` treats it
+    /// as "nobody was there to answer" and silently skips the offer instead
+    /// (see `main::offer_default_categories`).
     #[error(
         "multiple matches were found and no terminal is attached to ask which one; \
          re-run interactively, or identify the item unambiguously (by ID, or with \
@@ -43,10 +51,17 @@ pub enum PromptError {
     InvalidSelection(String),
 }
 
-/// Something that can present a list of labeled options to a user and
-/// return which one they picked (as a 0-based index into `options`).
+/// Something that can ask a user a question and report the answer.
 pub trait Prompter {
+    /// Presents a list of labeled options and returns which one the user
+    /// picked, as a 0-based index into `options`.
     fn choose(&mut self, message: &str, options: &[String]) -> Result<usize, PromptError>;
+
+    /// Asks a yes/no question. `default_yes` is the answer an empty response
+    /// (a bare Enter) means, and is reflected in the `[Y/n]` / `[y/N]` hint
+    /// the interactive implementation prints - so the caller decides which
+    /// way the prompt leans rather than each implementation hardcoding it.
+    fn confirm(&mut self, question: &str, default_yes: bool) -> Result<bool, PromptError>;
 }
 
 /// Parses and range-checks a raw line of input against `option_count`.
@@ -61,6 +76,21 @@ fn parse_selection(line: &str, option_count: usize) -> Result<usize, PromptError
         return Err(PromptError::InvalidSelection(trimmed.to_string()));
     }
     Ok(choice - 1)
+}
+
+/// Interprets a raw line of input as a yes/no answer, returning `None` for
+/// anything unrecognized so the caller can re-ask. An empty line (a bare
+/// Enter) means the offered default, which is what makes the first-run
+/// prompt "default to yes" (issue #27). Factored out for the same reason as
+/// `parse_selection`: it is the interesting logic, and it is unit-testable
+/// without a terminal.
+fn parse_confirmation(line: &str, default_yes: bool) -> Option<bool> {
+    match line.trim().to_ascii_lowercase().as_str() {
+        "" => Some(default_yes),
+        "y" | "yes" => Some(true),
+        "n" | "no" => Some(false),
+        _ => None,
+    }
 }
 
 /// The real, interactive prompter used by the CLI binary.
@@ -91,14 +121,88 @@ impl Prompter for StdinPrompter {
 
         parse_selection(&line, options.len())
     }
+
+    fn confirm(&mut self, question: &str, default_yes: bool) -> Result<bool, PromptError> {
+        let stdin = io::stdin();
+        if !stdin.is_terminal() {
+            return Err(PromptError::NotInteractive);
+        }
+
+        let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
+        loop {
+            print!("{question} {hint} ");
+            let _ = io::stdout().flush();
+
+            let mut line = String::new();
+            let bytes_read = stdin
+                .lock()
+                .read_line(&mut line)
+                .map_err(|_| PromptError::Eof)?;
+            if bytes_read == 0 {
+                return Err(PromptError::Eof);
+            }
+
+            // Unlike `choose`, an unrecognized answer here is not fatal: the
+            // question is cheap to repeat and there is no numbered list the
+            // user has to re-read, so re-asking beats aborting whatever
+            // command they actually ran.
+            if let Some(answer) = parse_confirmation(&line, default_yes) {
+                return Ok(answer);
+            }
+            println!("Please answer 'y' or 'n'.");
+        }
+    }
+}
+
+/// A prompter that never touches stdin, backing the global `--yes` and
+/// `--no-input` flags: every confirmation is answered with a fixed policy,
+/// so automation and CI can drive the binary without a terminal and without
+/// ever blocking.
+///
+/// `choose` deliberately still reports `NotInteractive`: "assume yes" has no
+/// meaningful answer to "which of these three tasks did you mean?", and
+/// silently picking one would operate on a task the user never named. Both
+/// flags therefore mean the same thing for `choose` - identify the item
+/// unambiguously instead.
+pub struct NonInteractivePrompter {
+    answer: bool,
+}
+
+impl NonInteractivePrompter {
+    /// `--yes`: take the offer without asking.
+    pub fn assuming_yes() -> Self {
+        Self { answer: true }
+    }
+
+    /// `--no-input`: decline without asking. This is a real answer, not an
+    /// absent one - a declined first-run offer is recorded and never made
+    /// again (see `main::offer_default_categories`).
+    pub fn assuming_no() -> Self {
+        Self { answer: false }
+    }
+}
+
+impl Prompter for NonInteractivePrompter {
+    fn choose(&mut self, _message: &str, _options: &[String]) -> Result<usize, PromptError> {
+        Err(PromptError::NotInteractive)
+    }
+
+    fn confirm(&mut self, _question: &str, _default_yes: bool) -> Result<bool, PromptError> {
+        Ok(self.answer)
+    }
 }
 
 /// Test double that answers with a pre-scripted sequence of results,
 /// exercising the exact same `Prompter` seam production code uses - no
 /// terminal, no stdin, no flakiness, and no risk of a hung test process.
+///
+/// The two question kinds get separate queues: a test that scripts a
+/// disambiguation choice should not have to know whether some unrelated
+/// confirmation happened to be asked first.
 #[cfg(test)]
 pub struct ScriptedPrompter {
     answers: std::collections::VecDeque<Result<usize, PromptError>>,
+    confirmations: std::collections::VecDeque<Result<bool, PromptError>>,
 }
 
 #[cfg(test)]
@@ -106,6 +210,14 @@ impl ScriptedPrompter {
     pub fn new(answers: Vec<Result<usize, PromptError>>) -> Self {
         Self {
             answers: answers.into(),
+            confirmations: std::collections::VecDeque::new(),
+        }
+    }
+
+    pub fn with_confirmations(confirmations: Vec<Result<bool, PromptError>>) -> Self {
+        Self {
+            answers: std::collections::VecDeque::new(),
+            confirmations: confirmations.into(),
         }
     }
 }
@@ -119,6 +231,12 @@ impl Prompter for ScriptedPrompter {
             Some(Err(e)) => Err(e),
             None => Err(PromptError::Eof),
         }
+    }
+
+    fn confirm(&mut self, _question: &str, _default_yes: bool) -> Result<bool, PromptError> {
+        self.confirmations
+            .pop_front()
+            .unwrap_or(Err(PromptError::Eof))
     }
 }
 
@@ -161,6 +279,65 @@ mod tests {
         let mut prompter = ScriptedPrompter::new(vec![]);
         let options = vec!["a".to_string()];
         assert_eq!(prompter.choose("pick", &options), Err(PromptError::Eof));
+    }
+
+    /// A bare Enter takes whichever default the caller offered - this is what
+    /// makes the first-run offer "default to yes" (issue #27).
+    #[test]
+    fn parse_confirmation_treats_an_empty_line_as_the_offered_default() {
+        assert_eq!(parse_confirmation("\n", true), Some(true));
+        assert_eq!(parse_confirmation("   \n", true), Some(true));
+        assert_eq!(parse_confirmation("", false), Some(false));
+    }
+
+    #[test]
+    fn parse_confirmation_accepts_both_spellings_in_either_case() {
+        for yes in ["y", "Y", "yes", "YES", " Yes \n"] {
+            assert_eq!(parse_confirmation(yes, false), Some(true), "{yes:?}");
+        }
+        for no in ["n", "N", "no", "NO", " No \n"] {
+            assert_eq!(parse_confirmation(no, true), Some(false), "{no:?}");
+        }
+    }
+
+    /// `None` means "ask again" rather than "take the default": silently
+    /// creating categories because the user typo'd would be a surprise.
+    #[test]
+    fn parse_confirmation_rejects_anything_else() {
+        assert_eq!(parse_confirmation("maybe", true), None);
+        assert_eq!(parse_confirmation("1", true), None);
+    }
+
+    /// `--yes` / `--no-input` answer confirmations from a fixed policy and
+    /// never read stdin, but must not invent an answer to `choose`.
+    #[test]
+    fn non_interactive_prompter_answers_confirmations_but_not_choices() {
+        let options = vec!["a".to_string(), "b".to_string()];
+
+        let mut yes = NonInteractivePrompter::assuming_yes();
+        assert_eq!(yes.confirm("go?", true), Ok(true));
+        // The offered default is ignored - the flag is the answer.
+        assert_eq!(yes.confirm("go?", false), Ok(true));
+        assert_eq!(
+            yes.choose("pick", &options),
+            Err(PromptError::NotInteractive)
+        );
+
+        let mut no = NonInteractivePrompter::assuming_no();
+        assert_eq!(no.confirm("go?", true), Ok(false));
+        assert_eq!(
+            no.choose("pick", &options),
+            Err(PromptError::NotInteractive)
+        );
+    }
+
+    #[test]
+    fn scripted_prompter_replays_confirmations_from_their_own_queue() {
+        let mut prompter = ScriptedPrompter::with_confirmations(vec![Ok(true), Ok(false)]);
+        assert_eq!(prompter.confirm("go?", true), Ok(true));
+        assert_eq!(prompter.confirm("go?", true), Ok(false));
+        // Exhausted, like `choose`.
+        assert_eq!(prompter.confirm("go?", true), Err(PromptError::Eof));
     }
 
     #[test]

--- a/src/prompter.rs
+++ b/src/prompter.rs
@@ -3,10 +3,10 @@
 //! The README says: "When operating on a `task_name`, the application will
 //! try to match the name - if it encounters the same name in multiple
 //! categories, it will prompt the user for which item on which to operate."
-//! A prior attempt at this (PR #15) wired that up with a bare inline
+//! An earlier attempt wired that up with a bare inline
 //! `std::io::stdin().read_line(...)` call, which made it impossible to write
 //! a test that exercises the disambiguation flow without a real terminal
-//! attached - that PR was rejected for exactly this reason.
+//! attached - it was rejected for exactly this reason.
 //!
 //! `Prompter` factors "ask the user something" behind a trait, so:
 //!   - production code uses `StdinPrompter`, which reads real input but
@@ -23,7 +23,7 @@
 //!   - `choose`, "pick one of these labelled options" (the ambiguous-task
 //!     flow above, and the deferred `reset` command);
 //!   - `confirm`, "yes or no?" (the first-run offer to create the default
-//!     "Home"/"Work" categories, issue #27).
+//!     "Home"/"Work" categories).
 
 use std::io::{self, BufRead, IsTerminal, Write};
 use thiserror::Error;
@@ -81,7 +81,7 @@ fn parse_selection(line: &str, option_count: usize) -> Result<usize, PromptError
 /// Interprets a raw line of input as a yes/no answer, returning `None` for
 /// anything unrecognized so the caller can re-ask. An empty line (a bare
 /// Enter) means the offered default, which is what makes the first-run
-/// prompt "default to yes" (issue #27). Factored out for the same reason as
+/// prompt "default to yes". Factored out for the same reason as
 /// `parse_selection`: it is the interesting logic, and it is unit-testable
 /// without a terminal.
 fn parse_confirmation(line: &str, default_yes: bool) -> Option<bool> {
@@ -282,7 +282,7 @@ mod tests {
     }
 
     /// A bare Enter takes whichever default the caller offered - this is what
-    /// makes the first-run offer "default to yes" (issue #27).
+    /// makes the first-run offer "default to yes".
     #[test]
     fn parse_confirmation_treats_an_empty_line_as_the_offered_default() {
         assert_eq!(parse_confirmation("\n", true), Some(true));

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -20,8 +20,8 @@ impl Storage for ConfigStorage {
         // The config file holds only the config half of `StorageData` (tasks
         // and categories live in the separate data file). Cloning the whole
         // `Config` rather than rebuilding it field by field means a newly
-        // added field - like issue #27's `default_categories_offered` marker
-        // - can't be silently dropped on save.
+        // added field - like the `default_categories_offered` first-run
+        // marker - can't be silently dropped on save.
         let config = data.config.clone();
 
         // Create parent directories if they don't exist
@@ -130,7 +130,7 @@ mod tests {
             loaded_data.config.default_priority,
             Some("medium".to_string())
         );
-        // The issue #27 first-run marker round-trips like any other field.
+        // The first-run marker round-trips like any other field.
         assert_eq!(loaded_data.config.default_categories_offered, Some(true));
     }
 
@@ -163,11 +163,11 @@ mod tests {
         assert_eq!(loaded_data.config.default_category, None);
         assert_eq!(loaded_data.config.default_priority, None);
         // No first-run marker either way, which is what makes both of these
-        // count as a first run (issue #27).
+        // count as a first run.
         assert_eq!(loaded_data.config.default_categories_offered, None);
     }
 
-    /// Regression test for issue #22's second half: writing a config with
+    /// Regression test: writing a config with
     /// only one field set must not materialize explicit JSON `null`s for the
     /// rest, or the next `load()` would see those keys as *present* and
     /// never fall back to a default for them.

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -17,14 +17,12 @@ impl ConfigStorage {
 
 impl Storage for ConfigStorage {
     fn save(&self, data: &crate::models::StorageData) -> Result<(), StorageError> {
-        // Convert StorageData to Config
-        let config = Config {
-            deleted_task_lifespan: data.config.deleted_task_lifespan,
-            storage_type: data.config.storage_type.clone(),
-            storage_path: data.config.storage_path.clone(),
-            default_category: data.config.default_category.clone(),
-            default_priority: data.config.default_priority.clone(),
-        };
+        // The config file holds only the config half of `StorageData` (tasks
+        // and categories live in the separate data file). Cloning the whole
+        // `Config` rather than rebuilding it field by field means a newly
+        // added field - like issue #27's `default_categories_offered` marker
+        // - can't be silently dropped on save.
+        let config = data.config.clone();
 
         // Create parent directories if they don't exist
         if let Some(parent) = self.path.parent() {
@@ -107,6 +105,7 @@ mod tests {
                 storage_path: Some("~/.config/trtodo".to_string()),
                 default_category: Some("work".to_string()),
                 default_priority: Some("medium".to_string()),
+                default_categories_offered: Some(true),
             },
             current_category: None,
             last_sync: chrono::Utc::now(),
@@ -131,6 +130,8 @@ mod tests {
             loaded_data.config.default_priority,
             Some("medium".to_string())
         );
+        // The issue #27 first-run marker round-trips like any other field.
+        assert_eq!(loaded_data.config.default_categories_offered, Some(true));
     }
 
     // Values unchanged from before this fix (a missing file already produced
@@ -161,6 +162,9 @@ mod tests {
         assert_eq!(loaded_data.config.storage_path, None);
         assert_eq!(loaded_data.config.default_category, None);
         assert_eq!(loaded_data.config.default_priority, None);
+        // No first-run marker either way, which is what makes both of these
+        // count as a first run (issue #27).
+        assert_eq!(loaded_data.config.default_categories_offered, None);
     }
 
     /// Regression test for issue #22's second half: writing a config with

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -232,7 +232,7 @@ mod tests {
     }
 
     /// Data written before `deleted_at` existed has no such key on its tasks;
-    /// it must still load, coming back as "not deleted" (issue #29).
+    /// it must still load, coming back as "not deleted".
     #[test]
     fn test_load_task_without_deleted_at_field() {
         let dir = tempdir().unwrap();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -43,7 +43,7 @@ impl StorageType {
     /// *directory*.
     ///
     /// Every backend gets its own file name on purpose. Pointing two backends
-    /// at one path is how issue #17's original "file is not a database" panic
+    /// at one path is how the original "file is not a database" panic
     /// happened, and how `JsonStorage::save` (a bare `std::fs::write`, with no
     /// format check) could silently clobber a SQLite database. Distinct names
     /// make that structurally impossible rather than merely unlikely - at the
@@ -190,7 +190,7 @@ pub trait Storage {
     ///
     /// Unlike `get_next_task_id`, this deliberately fills gaps rather than
     /// always handing out `max + 1`: the README specifies that "when deleting a
-    /// category it is removed and its ID is made available again" (issue #16).
+    /// category it is removed and its ID is made available again".
     /// ID 0 is never returned - it is reserved for the magic "Uncategorized"
     /// category.
     fn get_next_category_id(&self) -> Result<u64, StorageError> {
@@ -268,8 +268,8 @@ pub trait Storage {
     /// meaning "Uncategorized" (`category_manager::UNCATEGORIZED_ID`):
     /// deleting a *category* reassigns its tasks to 0, which would make them
     /// show up here as deleted and be destroyed by a purge the user never
-    /// asked for. Issue #29 fixed this by keying deletion off `deleted_at`
-    /// instead of `category_id`, so category deletion and task deletion can
+    /// asked for. Keying deletion off `deleted_at` instead of
+    /// `category_id` fixed that, so category deletion and task deletion can
     /// no longer be confused with each other.
     fn get_deleted_tasks(&self) -> Result<Vec<Task>, StorageError> {
         let data = self.load()?;
@@ -426,7 +426,7 @@ pub trait Storage {
 
 /// What `migrate_storage` actually did, so the caller can tell the user the
 /// truth instead of printing an unconditional "may require data migration"
-/// warning (issue #17).
+/// warning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MigrationOutcome {
     /// The source store holds no tasks and no categories, so there was
@@ -453,7 +453,7 @@ fn is_empty(data: &StorageData) -> bool {
 
 /// Copies everything in `source` into `destination`, for when the user
 /// changes `storage.type` and would otherwise watch all their tasks and
-/// categories vanish (issue #17).
+/// categories vanish.
 ///
 /// Backend-agnostic on purpose: it speaks only `Storage`, so json -> sqlite
 /// and sqlite -> json are the same code path, and any future backend gets the
@@ -564,7 +564,7 @@ mod tests {
         data
     }
 
-    /// The headline issue #17 behaviour: switching backends must carry the
+    /// The headline behaviour: switching backends must carry the
     /// user's data across, not silently strand it in a file nothing reads
     /// anymore. Exercised across *real* backends (JSON -> SQLite), since the
     /// whole point is that the two formats are involved.
@@ -729,7 +729,7 @@ mod tests {
 
     /// The file names are what keep the two backends from ever being pointed
     /// at the same path (see `StorageType::data_file_name`), so they are worth
-    /// pinning: making them equal would silently re-open issue #17's original
+    /// pinning: making them equal would silently re-open the original
     /// "file is not a database" failure.
     #[test]
     fn test_each_backend_has_its_own_data_file_name() {
@@ -761,7 +761,7 @@ mod tests {
         assert!(sqlite_storage.load().is_ok());
     }
 
-    /// Encodes the requirement from issue #17: switching storage backends against
+    /// Switching storage backends against
     /// a file that already holds data in a *different* backend's format must fail
     /// gracefully with a typed `StorageError`, not panic and not silently succeed
     /// with wrong/empty data.
@@ -811,14 +811,14 @@ mod tests {
         );
     }
 
-    /// Issue #29 regression test: deleting a *category* reassigns its tasks
+    /// Regression test: deleting a *category* reassigns its tasks
     /// to the magic "Uncategorized" ID (`category_manager::UNCATEGORIZED_ID`,
     /// which is 0). Before this fix, `get_deleted_tasks` treated
     /// `category_id == 0` as "this task is deleted", so a task merely
     /// orphaned by deleting its category would be misreported as deleted -
     /// and a subsequent `purge_deleted_tasks` flush would destroy it, even
-    /// though the user never asked to delete that task. This is the
-    /// data-loss scenario #29 exists to close off.
+    /// though the user never asked to delete that task. That is the
+    /// data-loss scenario soft deletion exists to close off.
     #[test]
     fn test_category_deletion_does_not_orphan_tasks_into_deleted() {
         use crate::category_manager::{CategoryManager, UNCATEGORIZED_ID};
@@ -854,7 +854,7 @@ mod tests {
         let deleted = storage.get_deleted_tasks().unwrap();
         assert!(
             deleted.is_empty(),
-            "task orphaned by category deletion must not appear in get_deleted_tasks (issue #29)"
+            "task orphaned by category deletion must not appear in get_deleted_tasks"
         );
     }
 
@@ -937,7 +937,7 @@ mod tests {
     /// `purge_deleted_tasks(n)` must key strictly off `deleted_at`, dropping
     /// tasks deleted more than `n` days ago and keeping recently-deleted
     /// ones. Crucially, a task's `updated_at` must have no bearing on this -
-    /// that decoupling was the second bug named in issue #29 (editing a
+    /// that decoupling fixed a second, subtler bug (editing a
     /// soft-deleted task used to silently reset its purge clock, because the
     /// old implementation judged `updated_at` instead of `deleted_at`).
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,10 +10,52 @@ pub mod sqlite;
 pub mod test_utils;
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StorageType {
     Json,
     Sqlite,
+}
+
+impl StorageType {
+    /// Parses the `storage.type` config value. Returns `None` for anything
+    /// that isn't a backend this build knows about, leaving it to the caller
+    /// to decide whether that is an error (`main::open_storage`) or simply
+    /// "not my business" (`main`'s pre-`set` migration hook, which lets
+    /// `ConfigManager::set`'s own validation produce the message).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "json" => Some(StorageType::Json),
+            "sqlite" => Some(StorageType::Sqlite),
+            _ => None,
+        }
+    }
+
+    /// The `storage.type` config value this backend is selected by. Kept
+    /// alongside `parse` so the two can't drift apart.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StorageType::Json => "json",
+            StorageType::Sqlite => "sqlite",
+        }
+    }
+
+    /// The name of the data file this backend keeps inside the `storage.path`
+    /// *directory*.
+    ///
+    /// Every backend gets its own file name on purpose. Pointing two backends
+    /// at one path is how issue #17's original "file is not a database" panic
+    /// happened, and how `JsonStorage::save` (a bare `std::fs::write`, with no
+    /// format check) could silently clobber a SQLite database. Distinct names
+    /// make that structurally impossible rather than merely unlikely - at the
+    /// cost that switching `storage.type` leaves the old backend's file
+    /// sitting there unread, which is what `migrate_storage` below exists to
+    /// deal with.
+    pub fn data_file_name(self) -> &'static str {
+        match self {
+            StorageType::Json => "trtodo-data.json",
+            StorageType::Sqlite => "trtodo-data.db",
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -382,6 +424,96 @@ pub trait Storage {
     }
 }
 
+/// What `migrate_storage` actually did, so the caller can tell the user the
+/// truth instead of printing an unconditional "may require data migration"
+/// warning (issue #17).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationOutcome {
+    /// The source store holds no tasks and no categories, so there was
+    /// nothing to carry over. The common case on a first-ever switch.
+    SourceEmpty,
+    /// The destination store already holds data of its own. Nothing was
+    /// copied and, crucially, nothing was overwritten - the user is switching
+    /// back to a backend they had already been using.
+    DestinationNotEmpty { tasks: usize, categories: usize },
+    /// The source's contents were copied into the (previously empty)
+    /// destination. The source is left exactly as it was.
+    Migrated { tasks: usize, categories: usize },
+}
+
+/// True when a store holds nothing a user would recognise as their data.
+///
+/// Deliberately judged on tasks and categories only. `current_category` is
+/// not considered: a context can only ever point at a category that exists,
+/// so with no categories it is at best stale, and treating it as "content"
+/// would block a perfectly good migration.
+fn is_empty(data: &StorageData) -> bool {
+    data.tasks.is_empty() && data.categories.is_empty()
+}
+
+/// Copies everything in `source` into `destination`, for when the user
+/// changes `storage.type` and would otherwise watch all their tasks and
+/// categories vanish (issue #17).
+///
+/// Backend-agnostic on purpose: it speaks only `Storage`, so json -> sqlite
+/// and sqlite -> json are the same code path, and any future backend gets the
+/// behaviour for free.
+///
+/// The rules it holds to, in order:
+///
+///   - **Never destructive.** The source is only ever `load`ed, never written
+///     to and never removed. After a migration both stores hold the data, and
+///     switching `storage.type` back is enough to reach the original.
+///   - **Never clobbers a non-empty destination.** If the destination already
+///     has tasks or categories - the "I'm switching back to the backend I
+///     used last week" case - this reports `DestinationNotEmpty` and writes
+///     nothing at all. Silently overwriting it would be exactly the data loss
+///     this function exists to prevent.
+///   - **IDs are preserved verbatim, never renumbered.** That is only sound
+///     because of the rule above: the destination is empty, so there is
+///     nothing for the source's IDs to collide with. This is also why no
+///     merge is attempted - reconciling two populated stores would mean
+///     renumbering tasks and categories, silently invalidating every ID the
+///     user has memorised or scripted against. Refusing is the coherent
+///     answer; a merge would need its own design and its own issue.
+///
+/// `current_category` rides along, so the user's `category use` context
+/// survives the switch. The vestigial `config` blob does not: it belongs to
+/// whichever file it is written in (see `StorageData::new`), so the
+/// destination keeps its own.
+#[allow(dead_code)]
+pub fn migrate_storage(
+    source: &dyn Storage,
+    destination: &dyn Storage,
+) -> Result<MigrationOutcome, StorageError> {
+    let source_data = source.load()?;
+    if is_empty(&source_data) {
+        return Ok(MigrationOutcome::SourceEmpty);
+    }
+
+    let destination_data = destination.load()?;
+    if !is_empty(&destination_data) {
+        return Ok(MigrationOutcome::DestinationNotEmpty {
+            tasks: destination_data.tasks.len(),
+            categories: destination_data.categories.len(),
+        });
+    }
+
+    let tasks = source_data.tasks.len();
+    let categories = source_data.categories.len();
+
+    destination.save(&StorageData {
+        version: destination_data.version,
+        tasks: source_data.tasks,
+        categories: source_data.categories,
+        config: destination_data.config,
+        current_category: source_data.current_category,
+        last_sync: chrono::Utc::now(),
+    })?;
+
+    Ok(MigrationOutcome::Migrated { tasks, categories })
+}
+
 #[allow(dead_code)]
 pub fn create_storage(
     storage_type: StorageType,
@@ -403,7 +535,214 @@ pub fn create_storage(
 mod tests {
     use super::*;
     use chrono::Utc;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
+
+    /// A category and a task belonging to it, with explicit non-zero IDs so
+    /// migration tests can assert the IDs survived rather than coincidentally
+    /// matching a default of 0.
+    fn populated_data() -> StorageData {
+        let mut data = StorageData::new();
+
+        let mut work = Category::new("Work".to_string(), None).unwrap();
+        work.id = 4;
+        let mut personal = Category::new("Personal".to_string(), None).unwrap();
+        personal.id = 9;
+
+        let mut report = Task::new("Finish report".to_string(), work.id, None, Priority::High)
+            .expect("valid task");
+        report.id = 12;
+        let mut groceries = Task::new("Buy milk".to_string(), personal.id, None, Priority::Low)
+            .expect("valid task");
+        groceries.id = 30;
+
+        data.categories.push(work);
+        data.categories.push(personal);
+        data.tasks.push(report);
+        data.tasks.push(groceries);
+        data.current_category = Some(9);
+
+        data
+    }
+
+    /// The headline issue #17 behaviour: switching backends must carry the
+    /// user's data across, not silently strand it in a file nothing reads
+    /// anymore. Exercised across *real* backends (JSON -> SQLite), since the
+    /// whole point is that the two formats are involved.
+    #[test]
+    fn test_migrate_storage_carries_data_across_backends() {
+        let dir = TempDir::new().unwrap();
+        let json_path = dir.path().join("trtodo-data.json");
+        let sqlite_path = dir.path().join("trtodo-data.db");
+
+        let source = create_storage(StorageType::Json, &json_path).unwrap();
+        source.save(&populated_data()).unwrap();
+
+        let destination = create_storage(StorageType::Sqlite, &sqlite_path).unwrap();
+        let outcome = migrate_storage(&*source, &*destination).unwrap();
+        assert_eq!(
+            outcome,
+            MigrationOutcome::Migrated {
+                tasks: 2,
+                categories: 2
+            }
+        );
+
+        let migrated = destination.load().unwrap();
+        assert_eq!(migrated.tasks.len(), 2);
+        assert_eq!(migrated.categories.len(), 2);
+
+        // IDs are carried over verbatim - a user's memorised/scripted task IDs
+        // must not be renumbered by a backend switch.
+        let mut task_ids: Vec<u64> = migrated.tasks.iter().map(|t| t.id).collect();
+        task_ids.sort_unstable();
+        assert_eq!(task_ids, vec![12, 30]);
+        let mut category_ids: Vec<u64> = migrated.categories.iter().map(|c| c.id).collect();
+        category_ids.sort_unstable();
+        assert_eq!(category_ids, vec![4, 9]);
+
+        // ... as is the `category use` context.
+        assert_eq!(migrated.current_category, Some(9));
+
+        // Non-destructive: the source still holds everything it did, and the
+        // file is still there to be switched back to.
+        assert!(json_path.exists());
+        let source_after = source.load().unwrap();
+        assert_eq!(source_after.tasks.len(), 2);
+        assert_eq!(source_after.categories.len(), 2);
+        assert_eq!(source_after.current_category, Some(9));
+    }
+
+    /// The same must hold in the other direction - `migrate_storage` speaks
+    /// only the `Storage` trait, and this pins that it really is symmetric
+    /// rather than accidentally JSON-shaped.
+    #[test]
+    fn test_migrate_storage_carries_data_back_from_sqlite_to_json() {
+        let dir = TempDir::new().unwrap();
+        let source =
+            create_storage(StorageType::Sqlite, &dir.path().join("trtodo-data.db")).unwrap();
+        source.save(&populated_data()).unwrap();
+
+        let destination =
+            create_storage(StorageType::Json, &dir.path().join("trtodo-data.json")).unwrap();
+        assert_eq!(
+            migrate_storage(&*source, &*destination).unwrap(),
+            MigrationOutcome::Migrated {
+                tasks: 2,
+                categories: 2
+            }
+        );
+
+        let migrated = destination.load().unwrap();
+        assert_eq!(migrated.tasks.len(), 2);
+        assert_eq!(migrated.categories.len(), 2);
+        assert_eq!(migrated.current_category, Some(9));
+    }
+
+    /// A destination that already holds the user's data must never be
+    /// overwritten - that would turn a confusing-but-recoverable backend
+    /// switch into real data loss. This is the "switching back to the backend
+    /// I used last week" case.
+    #[test]
+    fn test_migrate_storage_never_clobbers_a_non_empty_destination() {
+        let dir = TempDir::new().unwrap();
+        let json_path = dir.path().join("trtodo-data.json");
+        let sqlite_path = dir.path().join("trtodo-data.db");
+
+        let source = create_storage(StorageType::Sqlite, &sqlite_path).unwrap();
+        source.save(&populated_data()).unwrap();
+
+        // The destination has one category and no tasks of its own.
+        let destination = create_storage(StorageType::Json, &json_path).unwrap();
+        let mut existing = StorageData::new();
+        let mut kept = Category::new("Already here".to_string(), None).unwrap();
+        kept.id = 1;
+        existing.categories.push(kept);
+        destination.save(&existing).unwrap();
+        let before = std::fs::read_to_string(&json_path).unwrap();
+
+        assert_eq!(
+            migrate_storage(&*source, &*destination).unwrap(),
+            MigrationOutcome::DestinationNotEmpty {
+                tasks: 0,
+                categories: 1
+            }
+        );
+
+        // Nothing written at all, not even a re-serialization of what was
+        // already there.
+        assert_eq!(std::fs::read_to_string(&json_path).unwrap(), before);
+        let destination_after = destination.load().unwrap();
+        assert_eq!(destination_after.categories.len(), 1);
+        assert_eq!(destination_after.categories[0].name, "Already here");
+        assert!(destination_after.tasks.is_empty());
+
+        // And the source is, as always, untouched.
+        assert_eq!(source.load().unwrap().tasks.len(), 2);
+    }
+
+    /// A first-ever switch has nothing to carry over. That must be a silent
+    /// no-op rather than a write (or a scary warning) - the destination file
+    /// should not even be materialised with content.
+    #[test]
+    fn test_migrate_storage_reports_an_empty_source_without_writing() {
+        let dir = TempDir::new().unwrap();
+        let json_path = dir.path().join("trtodo-data.json");
+        let sqlite_path = dir.path().join("trtodo-data.db");
+
+        let source = create_storage(StorageType::Json, &json_path).unwrap();
+        let destination = create_storage(StorageType::Sqlite, &sqlite_path).unwrap();
+
+        assert_eq!(
+            migrate_storage(&*source, &*destination).unwrap(),
+            MigrationOutcome::SourceEmpty
+        );
+        assert!(destination.load().unwrap().tasks.is_empty());
+        assert!(destination.load().unwrap().categories.is_empty());
+    }
+
+    /// Soft-deleted tasks are still the user's data (they can be restored, and
+    /// `deleted flush` reports them), so they must ride along with everything
+    /// else rather than being quietly dropped by the switch.
+    #[test]
+    fn test_migrate_storage_carries_soft_deleted_tasks_too() {
+        let dir = TempDir::new().unwrap();
+        let source =
+            create_storage(StorageType::Json, &dir.path().join("trtodo-data.json")).unwrap();
+
+        let mut data = populated_data();
+        data.tasks[0].soft_delete();
+        source.save(&data).unwrap();
+
+        let destination =
+            create_storage(StorageType::Sqlite, &dir.path().join("trtodo-data.db")).unwrap();
+        assert_eq!(
+            migrate_storage(&*source, &*destination).unwrap(),
+            MigrationOutcome::Migrated {
+                tasks: 2,
+                categories: 2
+            }
+        );
+
+        assert_eq!(destination.get_deleted_tasks().unwrap().len(), 1);
+        assert_eq!(destination.live_tasks().unwrap().len(), 1);
+    }
+
+    /// The file names are what keep the two backends from ever being pointed
+    /// at the same path (see `StorageType::data_file_name`), so they are worth
+    /// pinning: making them equal would silently re-open issue #17's original
+    /// "file is not a database" failure.
+    #[test]
+    fn test_each_backend_has_its_own_data_file_name() {
+        assert_ne!(
+            StorageType::Json.data_file_name(),
+            StorageType::Sqlite.data_file_name()
+        );
+        assert_eq!(StorageType::parse("json"), Some(StorageType::Json));
+        assert_eq!(StorageType::parse("sqlite"), Some(StorageType::Sqlite));
+        assert_eq!(StorageType::parse("postgres"), None);
+        assert_eq!(StorageType::Json.as_str(), "json");
+        assert_eq!(StorageType::Sqlite.as_str(), "sqlite");
+    }
 
     #[test]
     fn test_storage_creation() {
@@ -435,13 +774,19 @@ mod tests {
     /// not silent success/corruption (verified: the original JSON file is left
     /// byte-for-byte intact and still loads correctly afterwards). This is not a
     /// deliberate validation in this codebase, though - it's an accidental
-    /// byproduct of the SQLite file format having a magic header. There is no
-    /// equivalent protection in the *other* direction (JSON backend silently
+    /// byproduct of the SQLite file format having a magic header. There is still
+    /// no equivalent protection in the *other* direction (JSON backend silently
     /// overwriting an existing SQLite file via `std::fs::write` with no format
     /// check at all), and there is no format check at all for two files that
-    /// both happen to satisfy their respective format's parser. #17 should stay
-    /// open for that gap; this test just pins down the one direction that
-    /// already behaves correctly today so a future regression is caught.
+    /// both happen to satisfy their respective format's parser.
+    ///
+    /// That gap is no longer *reachable through configuration*: each backend
+    /// now owns a distinct file name inside the `storage.path` directory (see
+    /// `StorageType::data_file_name`, pinned by
+    /// `test_each_backend_has_its_own_data_file_name`), so the two can't be
+    /// aimed at one file. This test still pins the one direction that behaves
+    /// correctly at the storage layer itself, for anyone who constructs the
+    /// backends directly.
     #[test]
     fn test_sqlite_rejects_json_populated_file() {
         let temp_file = NamedTempFile::new().unwrap();

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// Version history, so the number means something concrete:
 ///   - `1`: the original tables, with no `deleted_at` column on `tasks`.
-///   - `2`: `tasks.deleted_at` added for soft deletion (issue #29).
+///   - `2`: `tasks.deleted_at` added for soft deletion.
 ///
 /// Bump this *and* teach `initialize_schema` how to get a database from the
 /// previous version to the new one whenever the on-disk shape changes.
@@ -95,10 +95,10 @@ impl SqliteStorage {
     /// What it is *not*: a general migration system. There is no ordered
     /// `MIGRATIONS` list, no down-migrations, and no way to go from version N
     /// to N+2 other than by writing that step here by hand. `src/storage/
-    /// migrations.rs` used to gesture at one but never had a single migration
-    /// in it and was deleted in issue #23; issue #25 decided that rather than
-    /// resurrect it (or delete `schema_version` and lose the record of the
-    /// v1 -> v2 change), the table should simply get the reader it never had.
+    /// migrations.rs` used to gesture at one but never held a single
+    /// migration, and was deleted. Rather than resurrect it - or drop
+    /// `schema_version` and lose the record of the v1 -> v2 change - the
+    /// table was simply given the reader it never had.
     /// Designing the real thing is deferred until the schema settles - do not
     /// mistake the code below for it.
     fn initialize_schema(&self) -> Result<(), StorageError> {
@@ -154,7 +154,7 @@ impl SqliteStorage {
         conn.execute_batch(INIT_SCHEMA)
             .map_err(|e| StorageError::Storage(format!("Failed to initialize schema: {}", e)))?;
 
-        // Migrate pre-existing `tasks` tables (schema version 1, issue #29)
+        // Migrate pre-existing `tasks` tables (schema version 1)
         // that predate the `deleted_at` column. `PRAGMA table_info` lets us
         // check for the column's presence directly instead of trying the
         // `ALTER TABLE` and swallowing a "duplicate column" error, so this
@@ -265,8 +265,8 @@ impl Storage for SqliteStorage {
         //
         // That made every uncategorized task unstorable under SQLite - which
         // is now the *default* landing place for `add` with no `--category`
-        // (issue #33) and a routine thing to carry across a backend switch
-        // (issue #17). Rather than drop the foreign key, which is genuinely
+        // and a routine thing to carry across a backend switch. Rather than
+        // drop the foreign key, which is genuinely
         // worth having for real categories, we give it the one row it is
         // missing. `load` filters this row back out (see there), so the
         // sentinel is an implementation detail of this backend and is never
@@ -376,9 +376,9 @@ impl Storage for SqliteStorage {
             // Uncategorized and treat a *stored* one as data corruption, so
             // letting it escape here would be visible in two ways that both
             // matter: `first_run` decides a store is untouched by asking
-            // whether `get_all_categories` is empty (issue #27), and it would
+            // whether `get_all_categories` is empty, and it would
             // otherwise be copied into the other backend by a `storage.type`
-            // switch (issue #17). Filtering here keeps the sentinel local to
+            // switch. Filtering here keeps the sentinel local to
             // this backend, so both stay correct and JSON and SQLite continue
             // to load as exactly the same data.
             if category.id != UNCATEGORIZED_ID {
@@ -629,7 +629,7 @@ mod tests {
     }
 
     /// `deleted_at` must survive a save/load cycle in the SQLite backend,
-    /// same as every other task field (issue #29).
+    /// same as every other task field.
     #[test]
     fn test_deleted_at_round_trip() {
         let dir = TempDir::new().unwrap();
@@ -666,12 +666,11 @@ mod tests {
     /// failed", while JSON - which has no constraint - accepted the identical
     /// data. It stayed latent while `add` required `--category`; it became
     /// the default path once `--category` was made optional with
-    /// Uncategorized as the fallback (issue #33), and a routine one for
-    /// anyone carrying an uncategorized task across a `storage.type` switch
-    /// (issue #17).
+    /// Uncategorized as the fallback, and a routine one for
+    /// anyone carrying an uncategorized task across a `storage.type` switch.
     ///
     /// The second half is what keeps the sentinel from leaking: first-run
-    /// detection asks whether `get_all_categories` is empty (issue #27), so a
+    /// detection asks whether `get_all_categories` is empty, so a
     /// visible sentinel would make a fresh SQLite store look established and
     /// silently suppress the setup offer.
     #[test]
@@ -710,7 +709,7 @@ mod tests {
     /// A database created before `deleted_at` existed (schema version 1) has
     /// a `tasks` table with no such column. Opening it must migrate the
     /// column in place rather than erroring - this is what
-    /// `initialize_schema`'s `PRAGMA table_info` check guards (issue #29).
+    /// `initialize_schema`'s `PRAGMA table_info` check guards.
     #[test]
     fn test_migrates_pre_existing_database_without_deleted_at_column() {
         let dir = TempDir::new().unwrap();
@@ -791,9 +790,9 @@ mod tests {
         assert_eq!(version, SCHEMA_VERSION);
     }
 
-    /// Issue #25: `schema_version` used to be written once at database
-    /// creation and never read, so the number it held was decorative. It now
-    /// has a reader. On a brand-new database the seeded value must be the
+    /// `schema_version` used to be written once at database creation and
+    /// never read, so the number it held was decorative. It now has a
+    /// reader. On a brand-new database the seeded value must be the
     /// version this build actually writes, and re-opening must leave exactly
     /// one row saying so - a second row (or a bumped value) would mean the
     /// bookkeeping drifts every time the app starts.
@@ -821,7 +820,7 @@ mod tests {
         assert_eq!(read_versions(&storage), vec![SCHEMA_VERSION]);
     }
 
-    /// The reader's whole reason for existing (issue #25): a database written
+    /// The reader's whole reason for existing: a database written
     /// by a *newer* build carries a version this code has never heard of. Its
     /// tables may hold columns or constraints we don't know about, so opening
     /// it must fail with a message the user can act on rather than half-work

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -6,16 +6,29 @@ use rusqlite::{params, Connection, OptionalExtension};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+/// The schema this build knows how to read and write.
+///
+/// Version history, so the number means something concrete:
+///   - `1`: the original tables, with no `deleted_at` column on `tasks`.
+///   - `2`: `tasks.deleted_at` added for soft deletion (issue #29).
+///
+/// Bump this *and* teach `initialize_schema` how to get a database from the
+/// previous version to the new one whenever the on-disk shape changes.
 #[allow(dead_code)]
 const SCHEMA_VERSION: i32 = 2;
 
+/// Created and read before anything else, so `initialize_schema` can find out
+/// what it is dealing with *before* it starts mutating tables. Deliberately
+/// separate from `INIT_SCHEMA` below for that ordering alone.
 #[allow(dead_code)]
-const INIT_SCHEMA: &str = r#"
--- Create schema version table first
+const INIT_VERSION_TABLE: &str = r#"
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL
 );
+"#;
 
+#[allow(dead_code)]
+const INIT_SCHEMA: &str = r#"
 -- Create categories table
 CREATE TABLE IF NOT EXISTS categories (
     id INTEGER PRIMARY KEY,
@@ -69,6 +82,24 @@ impl SqliteStorage {
         Ok(storage)
     }
 
+    /// Brings the database at hand up to `SCHEMA_VERSION`, or refuses to touch
+    /// it if it cannot.
+    ///
+    /// What versioning here *is*: a guard rail plus one hand-written upgrade
+    /// step. `schema_version` is read back before any table is touched, an
+    /// unknown (newer) version is rejected outright with a message the user
+    /// can act on, and a version-1 database is upgraded in place by adding
+    /// the `deleted_at` column before the stored version is advanced.
+    ///
+    /// What it is *not*: a general migration system. There is no ordered
+    /// `MIGRATIONS` list, no down-migrations, and no way to go from version N
+    /// to N+2 other than by writing that step here by hand. `src/storage/
+    /// migrations.rs` used to gesture at one but never had a single migration
+    /// in it and was deleted in issue #23; issue #25 decided that rather than
+    /// resurrect it (or delete `schema_version` and lose the record of the
+    /// v1 -> v2 change), the table should simply get the reader it never had.
+    /// Designing the real thing is deferred until the schema settles - do not
+    /// mistake the code below for it.
     fn initialize_schema(&self) -> Result<(), StorageError> {
         let conn = self
             .conn
@@ -79,7 +110,43 @@ impl SqliteStorage {
         conn.execute("PRAGMA foreign_keys = ON", [])
             .map_err(|e| StorageError::Storage(format!("Failed to enable foreign keys: {}", e)))?;
 
-        // First create the tables. `CREATE TABLE IF NOT EXISTS` is a no-op
+        // Read the stored version *first*, before any table is created or
+        // altered: if this database came from a build we don't understand, we
+        // want to have changed nothing by the time we bail out.
+        conn.execute_batch(INIT_VERSION_TABLE).map_err(|e| {
+            StorageError::Storage(format!("Failed to initialize schema version table: {}", e))
+        })?;
+
+        // `MAX(version)` rather than a bare `SELECT version`: it collapses an
+        // empty table (a brand-new database, or one seeded by some earlier
+        // build that never inserted a row) into a clean `None` instead of a
+        // `QueryReturnedNoRows` error, and it is robust to a stray duplicate
+        // row.
+        let stored_version: Option<i32> = conn
+            .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+                row.get(0)
+            })
+            .map_err(|e| StorageError::Storage(format!("Failed to read schema version: {}", e)))?;
+
+        // A version from the future is the one case we cannot handle: the
+        // tables may hold columns, constraints, or encodings this build has
+        // never heard of, and blundering on would either error somewhere far
+        // less comprehensible or quietly write data back in the older shape.
+        // Fail here, while the database is still untouched, and say exactly
+        // what happened.
+        if let Some(version) = stored_version {
+            if version > SCHEMA_VERSION {
+                return Err(StorageError::Storage(format!(
+                    "this database uses schema version {}, but this build of trtodo only \
+                     understands up to version {}; it was most likely written by a newer \
+                     version of trtodo. Upgrade trtodo, or point storage.path at a different \
+                     directory. The database has not been modified.",
+                    version, SCHEMA_VERSION
+                )));
+            }
+        }
+
+        // Now create the tables. `CREATE TABLE IF NOT EXISTS` is a no-op
         // against a database that already has a `tasks` table from before
         // `deleted_at` existed, so it will NOT retroactively add the column -
         // that is handled explicitly below.
@@ -105,32 +172,31 @@ impl SqliteStorage {
                 })?;
         }
 
-        // Check if schema_version table exists and has a version
-        let version_exists: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM schema_version WHERE version IS NOT NULL)",
-                [],
-                |row| row.get(0),
-            )
-            .map_err(|e| StorageError::Storage(format!("Failed to check schema version: {}", e)))?;
-
-        if !version_exists {
-            // Set initial schema version
-            conn.execute(
-                "INSERT INTO schema_version (version) VALUES (?1)",
-                params![SCHEMA_VERSION],
-            )
-            .map_err(|e| StorageError::Storage(format!("Failed to set schema version: {}", e)))?;
-        } else {
-            // Bring an older database's stored version up to date now that
-            // the migration above has run.
-            conn.execute(
-                "UPDATE schema_version SET version = ?1 WHERE version < ?1",
-                params![SCHEMA_VERSION],
-            )
-            .map_err(|e| {
-                StorageError::Storage(format!("Failed to update schema version: {}", e))
-            })?;
+        // Record where we ended up. Written last, after the upgrade above has
+        // actually succeeded, so a database that failed part way through is
+        // never left claiming a version it doesn't have.
+        match stored_version {
+            None => {
+                conn.execute(
+                    "INSERT INTO schema_version (version) VALUES (?1)",
+                    params![SCHEMA_VERSION],
+                )
+                .map_err(|e| {
+                    StorageError::Storage(format!("Failed to set schema version: {}", e))
+                })?;
+            }
+            Some(version) if version < SCHEMA_VERSION => {
+                conn.execute(
+                    "UPDATE schema_version SET version = ?1 WHERE version < ?1",
+                    params![SCHEMA_VERSION],
+                )
+                .map_err(|e| {
+                    StorageError::Storage(format!("Failed to update schema version: {}", e))
+                })?;
+            }
+            // Already current. The `>` case was rejected above, so this arm
+            // is exactly `version == SCHEMA_VERSION`: leave the row alone.
+            Some(_) => {}
         }
 
         Ok(())
@@ -622,6 +688,89 @@ mod tests {
             .query_row("SELECT version FROM schema_version", [], |row| row.get(0))
             .unwrap();
         assert_eq!(version, SCHEMA_VERSION);
+    }
+
+    /// Issue #25: `schema_version` used to be written once at database
+    /// creation and never read, so the number it held was decorative. It now
+    /// has a reader. On a brand-new database the seeded value must be the
+    /// version this build actually writes, and re-opening must leave exactly
+    /// one row saying so - a second row (or a bumped value) would mean the
+    /// bookkeeping drifts every time the app starts.
+    #[test]
+    fn test_schema_version_is_seeded_once_and_stays_put() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("versioned.db");
+
+        let read_versions = |storage: &SqliteStorage| -> Vec<i32> {
+            let conn = storage.conn.lock().unwrap();
+            let mut stmt = conn.prepare("SELECT version FROM schema_version").unwrap();
+            let rows: Vec<i32> = stmt
+                .query_map([], |row| row.get(0))
+                .unwrap()
+                .map(|v| v.unwrap())
+                .collect();
+            rows
+        };
+
+        let storage = SqliteStorage::new(&db_path).unwrap();
+        assert_eq!(read_versions(&storage), vec![SCHEMA_VERSION]);
+        drop(storage);
+
+        let storage = SqliteStorage::new(&db_path).unwrap();
+        assert_eq!(read_versions(&storage), vec![SCHEMA_VERSION]);
+    }
+
+    /// The reader's whole reason for existing (issue #25): a database written
+    /// by a *newer* build carries a version this code has never heard of. Its
+    /// tables may hold columns or constraints we don't know about, so opening
+    /// it must fail with a message the user can act on rather than half-work
+    /// and write data back in an older shape.
+    #[test]
+    fn test_rejects_a_database_from_a_newer_build() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("from_the_future.db");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE schema_version (version INTEGER NOT NULL);")
+                .unwrap();
+            conn.execute(
+                "INSERT INTO schema_version (version) VALUES (?1)",
+                params![SCHEMA_VERSION + 1],
+            )
+            .unwrap();
+        }
+
+        let message = match SqliteStorage::new(&db_path) {
+            Err(e) => e.to_string(),
+            Ok(_) => {
+                panic!("a database from a newer build must be rejected, not opened and written to")
+            }
+        };
+        assert!(
+            message.contains(&(SCHEMA_VERSION + 1).to_string())
+                && message.contains(&SCHEMA_VERSION.to_string()),
+            "the error should name both the version found and the version supported, got: {message}"
+        );
+        assert!(
+            message.contains("newer version of trtodo"),
+            "the error should explain *why* this happened, got: {message}"
+        );
+
+        // And it must have bailed out before touching anything: no tables were
+        // created behind the user's back.
+        let conn = Connection::open(&db_path).unwrap();
+        let table_count: i32 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('tasks', 'categories', 'current_category')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            table_count, 0,
+            "a rejected database must be left exactly as it was found"
+        );
     }
 
     #[test]

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1,5 +1,6 @@
 use super::Storage;
 use super::StorageError;
+use crate::category_manager::UNCATEGORIZED_ID;
 use crate::models::{Category, Priority, StorageData, Task};
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension};
@@ -251,6 +252,43 @@ impl Storage for SqliteStorage {
             })?;
         }
 
+        // Seed the Uncategorized sentinel row before any task is inserted.
+        //
+        // `Uncategorized` (ID 0) is synthesized by `CategoryManager` rather
+        // than stored - it cannot be created, renamed, or deleted, so it has
+        // no business being in `data.categories`, and it never is. But the
+        // `tasks.category_id` foreign key does not know that: a task filed
+        // under Uncategorized references a row that, without this, does not
+        // exist, and SQLite rejects the insert with "FOREIGN KEY constraint
+        // failed". JSON has no such constraint, so the same data saved fine
+        // there and only SQLite users hit it.
+        //
+        // That made every uncategorized task unstorable under SQLite - which
+        // is now the *default* landing place for `add` with no `--category`
+        // (issue #33) and a routine thing to carry across a backend switch
+        // (issue #17). Rather than drop the foreign key, which is genuinely
+        // worth having for real categories, we give it the one row it is
+        // missing. `load` filters this row back out (see there), so the
+        // sentinel is an implementation detail of this backend and is never
+        // visible to callers.
+        tx.execute(
+            "INSERT INTO categories (id, name, description, \"order\", created_at) \
+             VALUES (?1, ?2, NULL, ?3, ?4)",
+            // The name is immaterial - `load` filters this row out and
+            // callers synthesize their own - but it is spelled the same way
+            // so anyone opening the database with `sqlite3` sees something
+            // recognizable rather than a mystery row.
+            params![
+                UNCATEGORIZED_ID,
+                "Uncategorized",
+                0i64,
+                Utc::now().to_rfc3339()
+            ],
+        )
+        .map_err(|e| {
+            StorageError::Storage(format!("Failed to seed the Uncategorized category: {}", e))
+        })?;
+
         // Insert categories
         for category in &data.categories {
             tx.execute(
@@ -330,11 +368,22 @@ impl Storage for SqliteStorage {
             .map_err(|e| StorageError::Storage(format!("Failed to query categories: {}", e)))?;
 
         for category in category_iter {
-            categories.push(
-                category.map_err(|e| {
-                    StorageError::Storage(format!("Failed to read category: {}", e))
-                })?,
-            );
+            let category = category
+                .map_err(|e| StorageError::Storage(format!("Failed to read category: {}", e)))?;
+
+            // Hide the Uncategorized sentinel `save` seeds to satisfy the
+            // `tasks.category_id` foreign key. Callers synthesize their own
+            // Uncategorized and treat a *stored* one as data corruption, so
+            // letting it escape here would be visible in two ways that both
+            // matter: `first_run` decides a store is untouched by asking
+            // whether `get_all_categories` is empty (issue #27), and it would
+            // otherwise be copied into the other backend by a `storage.type`
+            // switch (issue #17). Filtering here keeps the sentinel local to
+            // this backend, so both stay correct and JSON and SQLite continue
+            // to load as exactly the same data.
+            if category.id != UNCATEGORIZED_ID {
+                categories.push(category);
+            }
         }
 
         // Load tasks
@@ -604,6 +653,58 @@ mod tests {
         data.tasks[0].restore();
         storage.save(&data).unwrap();
         assert!(storage.load().unwrap().tasks[0].deleted_at.is_none());
+    }
+
+    /// A task filed under the synthesized "Uncategorized" category (ID 0)
+    /// must save and load like any other, and must not drag the sentinel row
+    /// `save` seeds to satisfy the `tasks.category_id` foreign key back out
+    /// with it.
+    ///
+    /// This is a regression test for a real defect: because "Uncategorized"
+    /// is synthesized rather than stored, nothing satisfied that foreign key
+    /// and SQLite rejected every such insert with "FOREIGN KEY constraint
+    /// failed", while JSON - which has no constraint - accepted the identical
+    /// data. It stayed latent while `add` required `--category`; it became
+    /// the default path once `--category` was made optional with
+    /// Uncategorized as the fallback (issue #33), and a routine one for
+    /// anyone carrying an uncategorized task across a `storage.type` switch
+    /// (issue #17).
+    ///
+    /// The second half is what keeps the sentinel from leaking: first-run
+    /// detection asks whether `get_all_categories` is empty (issue #27), so a
+    /// visible sentinel would make a fresh SQLite store look established and
+    /// silently suppress the setup offer.
+    #[test]
+    fn test_uncategorized_tasks_round_trip_without_leaking_the_sentinel() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("uncategorized.db");
+        let storage = SqliteStorage::new(&db_path).unwrap();
+
+        let mut data = create_test_data();
+        data.tasks[0].category_id = UNCATEGORIZED_ID;
+        storage.save(&data).unwrap();
+
+        let loaded = storage.load().unwrap();
+        let task = loaded.tasks.iter().find(|t| t.id == 1).unwrap();
+        assert_eq!(task.category_id, UNCATEGORIZED_ID);
+
+        // The sentinel is an implementation detail and must stay invisible.
+        assert!(
+            !loaded.categories.iter().any(|c| c.id == UNCATEGORIZED_ID),
+            "the Uncategorized sentinel leaked out of the SQLite backend"
+        );
+        assert_eq!(loaded.categories.len(), data.categories.len());
+
+        // A store holding only uncategorized tasks still reports no
+        // categories, so first-run detection stays correct.
+        let mut empty = create_test_data();
+        empty.categories.clear();
+        empty.tasks.iter_mut().for_each(|t| {
+            t.category_id = UNCATEGORIZED_ID;
+        });
+        empty.current_category = None;
+        storage.save(&empty).unwrap();
+        assert!(storage.load().unwrap().categories.is_empty());
     }
 
     /// A database created before `deleted_at` existed (schema version 1) has

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -152,14 +152,14 @@ impl<'a> TaskManager<'a> {
         Ok(Some(task))
     }
 
-    /// Soft-deletes a task (issue #29): it disappears from every listing/
+    /// Soft-deletes a task: it disappears from every listing/
     /// search but keeps its real category and can still be found by ID.
     pub fn delete_task(&self, task_id: u64) -> Result<(), TaskManagerError> {
         Ok(self.storage.soft_delete_task(task_id)?)
     }
 
     /// Every currently soft-deleted task, oldest deletion first
-    /// (`trtodo deleted list`; issue #32).
+    /// (`trtodo deleted list`).
     ///
     /// Sorted by `deleted_at` deliberately: this list doubles as the preview
     /// of what a `flush` would destroy and of what the automatic
@@ -174,7 +174,7 @@ impl<'a> TaskManager<'a> {
     }
 
     /// Resolves a `<title or id>` CLI argument to a single *soft-deleted*
-    /// task, for `trtodo deleted restore` (issue #31).
+    /// task, for `trtodo deleted restore`.
     ///
     /// This is the inverse scope of `resolve_task`, and it has to be its own
     /// method rather than a flag on that one: every title/ID lookup helper
@@ -226,11 +226,12 @@ impl<'a> TaskManager<'a> {
         }
     }
 
-    /// Restores a soft-deleted task (issue #31), returning the category ID it
+    /// Restores a soft-deleted task, returning the category ID it
     /// actually landed in so the CLI can name it in its confirmation.
     ///
     /// Normally that is simply the task's own `category_id`, untouched since
-    /// before the delete - which is the entire point of issue #29's design.
+    /// before the delete - which is the entire point of soft deletion keeping
+    /// the real `category_id`.
     /// See `restore_destination` for the one case where it isn't.
     pub fn restore_task(&self, mut task: Task) -> Result<u64, TaskManagerError> {
         let destination =
@@ -259,7 +260,7 @@ impl<'a> TaskManager<'a> {
     /// why this is a distinct primitive from the automatic,
     /// `deleted-task-lifespan`-gated purge below.
     ///
-    /// Returns the tasks it removed, not just a count (issue #32): the CLI
+    /// Returns the tasks it removed, not just a count: the CLI
     /// reports *what* was destroyed, and by the time it could go and look
     /// the rows are gone. The snapshot is taken here, immediately before the
     /// purge, so what comes back is what this call actually destroyed -
@@ -357,8 +358,8 @@ impl<'a> TaskManager<'a> {
 }
 
 /// Where a restored task should land, given the category it remembers and
-/// whether that category still exists (issue #31 called this out as needing
-/// a decision rather than an accident).
+/// whether that category still exists. Worth a deliberate decision rather
+/// than an accident, since both outcomes are defensible.
 ///
 /// The decision: fall back to Uncategorized. A task whose category is gone
 /// still has to go *somewhere*, Uncategorized is the one category that can
@@ -384,8 +385,8 @@ fn restore_destination(category_id: u64, category_exists: bool) -> u64 {
 }
 
 /// Asks the user to confirm an irreversible `deleted flush` of `pending`
-/// tasks, through the same `Prompter` seam as every other prompt in the app
-/// (issue #32). Returns whether they said yes.
+/// tasks, through the same `Prompter` seam as every other prompt in the
+/// app. Returns whether they said yes.
 ///
 /// A `PromptError::NotInteractive` here is not a failure of this function -
 /// it is the answer "there is nobody to ask", which the CLI turns into a
@@ -579,7 +580,7 @@ mod tests {
         manager.delete_task(deleted_id).unwrap();
 
         // The flush reports the tasks it destroyed, not just how many
-        // (issue #32) - nobody can go and look afterwards.
+        // - nobody can go and look afterwards.
         let purged = manager.flush_deleted().unwrap();
         assert_eq!(purged.len(), 1);
         assert_eq!(purged[0].id, deleted_id);
@@ -765,8 +766,9 @@ mod tests {
             .unwrap();
         let destination = manager.restore_task(task).unwrap();
 
-        // Lossless: same category it was deleted from (issue #29's design
-        // is what makes this free), and the priority survives too.
+        // Lossless: same category it was deleted from (keeping the real
+        // `category_id` is what makes this free), and the priority survives
+        // too.
         assert_eq!(destination, 1);
         let restored = storage.get_task(id).unwrap().unwrap();
         assert!(!restored.is_deleted());

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -5,7 +5,16 @@
 //! (soft) delete, update, check/uncheck, moving tasks between categories,
 //! filtered listing, and the "match by name, prompt if ambiguous" rule (see
 //! `crate::prompter`).
+//!
+//! It also owns the *deleted* side of that world (`trtodo deleted ...`):
+//! listing what is soft-deleted, resolving a reference among only those
+//! tasks, restoring one, and flushing them all. Those live here rather than
+//! in a module of their own because they are the same tasks under a
+//! different scope - `resolve_deleted_task` is `resolve_task` with
+//! `live_tasks()` swapped for `get_deleted_tasks()`, and shares its
+//! disambiguation step verbatim.
 
+use crate::category_manager::UNCATEGORIZED_ID;
 use crate::models::{Priority, StorageError, Task, TaskError};
 use crate::prompter::{PromptError, Prompter};
 use crate::storage::Storage;
@@ -72,19 +81,33 @@ impl<'a> TaskManager<'a> {
                 .task_by_id_in_scope(reference, category_id)?
                 .ok_or_else(|| TaskManagerError::NotFound(reference.to_string())),
             1 => Ok(candidates.into_iter().next().expect("len checked above")),
-            _ => {
-                let labels: Vec<String> = candidates
-                    .iter()
-                    .map(|t| format!("#{} - {} (category {})", t.id, t.title, t.category_id))
-                    .collect();
-                let message = format!("Multiple tasks named '{reference}' were found; which one?");
-                let index = prompter.choose(&message, &labels)?;
-                Ok(candidates
-                    .into_iter()
-                    .nth(index)
-                    .expect("prompter must return an index within range"))
-            }
+            _ => Self::disambiguate(reference, candidates, prompter, |t| {
+                format!("#{} - {} (category {})", t.id, t.title, t.category_id)
+            }),
         }
+    }
+
+    /// The shared tail of `resolve_task` and `resolve_deleted_task`: several
+    /// tasks answer to the same reference, so the README's "prompt the user
+    /// for which item on which to operate" rule fires.
+    ///
+    /// `label` is a parameter rather than a fixed format because the two
+    /// callers have different things worth showing: a live match is told
+    /// apart by its category, while two *deleted* tasks with the same title
+    /// in the same category are told apart only by when each was deleted.
+    fn disambiguate(
+        reference: &str,
+        candidates: Vec<Task>,
+        prompter: &mut dyn Prompter,
+        label: impl Fn(&Task) -> String,
+    ) -> Result<Task, TaskManagerError> {
+        let labels: Vec<String> = candidates.iter().map(label).collect();
+        let message = format!("Multiple tasks named '{reference}' were found; which one?");
+        let index = prompter.choose(&message, &labels)?;
+        Ok(candidates
+            .into_iter()
+            .nth(index)
+            .expect("prompter must return an index within range"))
     }
 
     fn tasks_by_title_in_scope(
@@ -135,13 +158,116 @@ impl<'a> TaskManager<'a> {
         Ok(self.storage.soft_delete_task(task_id)?)
     }
 
+    /// Every currently soft-deleted task, oldest deletion first
+    /// (`trtodo deleted list`; issue #32).
+    ///
+    /// Sorted by `deleted_at` deliberately: this list doubles as the preview
+    /// of what a `flush` would destroy and of what the automatic
+    /// `deleted-task-lifespan` sweep will reach first, and both of those act
+    /// on the oldest deletions - so the tasks nearest destruction are the
+    /// ones at the top. `id` breaks ties, since two tasks deleted in the
+    /// same second are otherwise ordered arbitrarily.
+    pub fn list_deleted(&self) -> Result<Vec<Task>, TaskManagerError> {
+        let mut tasks = self.storage.get_deleted_tasks()?;
+        tasks.sort_by(|a, b| a.deleted_at.cmp(&b.deleted_at).then(a.id.cmp(&b.id)));
+        Ok(tasks)
+    }
+
+    /// Resolves a `<title or id>` CLI argument to a single *soft-deleted*
+    /// task, for `trtodo deleted restore` (issue #31).
+    ///
+    /// This is the inverse scope of `resolve_task`, and it has to be its own
+    /// method rather than a flag on that one: every title/ID lookup helper
+    /// on `Storage` routes through `live_tasks()` and so can never see a
+    /// deleted task, while `resolve_task` goes further and explicitly
+    /// rejects a by-ID hit whose `deleted_at` is set. Bending either to also
+    /// mean "but sometimes only the deleted ones" would put a
+    /// restore-shaped special case inside the path every ordinary task
+    /// command takes. Searching `get_deleted_tasks()` here keeps that risk
+    /// where it belongs: it is impossible for this method to return a live
+    /// task, and impossible for `resolve_task` to return a deleted one.
+    ///
+    /// There is no `category_id` scope parameter, and `deleted restore` has
+    /// no `--category`: a soft-deleted task is invisible to `list`, so the
+    /// user has no way to know which category the thing they want back was
+    /// in without running `deleted list` first - which prints the ID, and an
+    /// ID needs no disambiguation. An ambiguous *title* still prompts, via
+    /// the same `Prompter` seam every other task command uses.
+    pub fn resolve_deleted_task(
+        &self,
+        reference: &str,
+        prompter: &mut dyn Prompter,
+    ) -> Result<Task, TaskManagerError> {
+        let deleted = self.list_deleted()?;
+        let wanted = reference.to_lowercase();
+        // Case-insensitive, matching `Storage::get_tasks_by_title`.
+        let candidates: Vec<Task> = deleted
+            .iter()
+            .filter(|t| t.title.to_lowercase() == wanted)
+            .cloned()
+            .collect();
+
+        match candidates.len() {
+            0 => reference
+                .parse::<u64>()
+                .ok()
+                .and_then(|id| deleted.into_iter().find(|t| t.id == id))
+                .ok_or_else(|| TaskManagerError::NotFound(reference.to_string())),
+            1 => Ok(candidates.into_iter().next().expect("len checked above")),
+            _ => Self::disambiguate(reference, candidates, prompter, |t| {
+                format!(
+                    "#{} - {} (category {}, deleted {})",
+                    t.id,
+                    t.title,
+                    t.category_id,
+                    t.deleted_at_display()
+                )
+            }),
+        }
+    }
+
+    /// Restores a soft-deleted task (issue #31), returning the category ID it
+    /// actually landed in so the CLI can name it in its confirmation.
+    ///
+    /// Normally that is simply the task's own `category_id`, untouched since
+    /// before the delete - which is the entire point of issue #29's design.
+    /// See `restore_destination` for the one case where it isn't.
+    pub fn restore_task(&self, mut task: Task) -> Result<u64, TaskManagerError> {
+        let destination =
+            restore_destination(task.category_id, self.category_exists(task.category_id)?);
+        task.restore();
+        if destination != task.category_id {
+            task.move_to_category(destination);
+        }
+        self.storage.update_task(task)?;
+        Ok(destination)
+    }
+
+    /// Whether a task's `category_id` still refers to something real.
+    /// `UNCATEGORIZED_ID` always does: it is synthesized rather than stored
+    /// (see `CategoryManager::get_category`), so a plain storage lookup
+    /// would wrongly report it missing.
+    fn category_exists(&self, category_id: u64) -> Result<bool, StorageError> {
+        if category_id == UNCATEGORIZED_ID {
+            return Ok(true);
+        }
+        Ok(self.storage.get_category(category_id)?.is_some())
+    }
+
     /// Permanently removes every currently soft-deleted task, unconditionally
-    /// (`trtodo deleted flush`). Returns how many were removed, for the CLI
-    /// to report back to the user. See `Storage::purge_all_deleted_tasks`
-    /// for why this is a distinct primitive from the automatic,
+    /// (`trtodo deleted flush`). See `Storage::purge_all_deleted_tasks` for
+    /// why this is a distinct primitive from the automatic,
     /// `deleted-task-lifespan`-gated purge below.
-    pub fn flush_deleted(&self) -> Result<usize, TaskManagerError> {
-        Ok(self.storage.purge_all_deleted_tasks()?)
+    ///
+    /// Returns the tasks it removed, not just a count (issue #32): the CLI
+    /// reports *what* was destroyed, and by the time it could go and look
+    /// the rows are gone. The snapshot is taken here, immediately before the
+    /// purge, so what comes back is what this call actually destroyed -
+    /// never a stale list assembled somewhere further up.
+    pub fn flush_deleted(&self) -> Result<Vec<Task>, TaskManagerError> {
+        let flushed = self.list_deleted()?;
+        self.storage.purge_all_deleted_tasks()?;
+        Ok(flushed)
     }
 
     /// Automatically purges tasks that were soft-deleted more than
@@ -228,6 +354,56 @@ impl<'a> TaskManager<'a> {
 
         Ok(tasks)
     }
+}
+
+/// Where a restored task should land, given the category it remembers and
+/// whether that category still exists (issue #31 called this out as needing
+/// a decision rather than an accident).
+///
+/// The decision: fall back to Uncategorized. A task whose category is gone
+/// still has to go *somewhere*, Uncategorized is the one category that can
+/// never be deleted (it is synthesized, not stored), and it is already where
+/// `CategoryManager::delete_category` sends orphaned tasks - so a restore
+/// lands the task exactly where it would have been had it been live all
+/// along. Refusing the restore instead would leave the user's only copy of
+/// the task in the one place a `flush` destroys.
+///
+/// In practice this is a backstop, not a path users can reach:
+/// `delete_category` rewrites the `category_id` of *every* task in the
+/// category it removes, soft-deleted ones included, and `StorageData::validate`
+/// rejects a dangling task->category reference on both save and load. It is
+/// implemented anyway because the alternative - a restore that silently
+/// resurrects a task into a category that isn't there - is a data-integrity
+/// error that would only surface much later.
+fn restore_destination(category_id: u64, category_exists: bool) -> u64 {
+    if category_exists {
+        category_id
+    } else {
+        UNCATEGORIZED_ID
+    }
+}
+
+/// Asks the user to confirm an irreversible `deleted flush` of `pending`
+/// tasks, through the same `Prompter` seam as every other prompt in the app
+/// (issue #32). Returns whether they said yes.
+///
+/// A `PromptError::NotInteractive` here is not a failure of this function -
+/// it is the answer "there is nobody to ask", which the CLI turns into a
+/// refusal to flush. See `main::run_deleted_command`.
+///
+/// "No" is offered first, so the reflexive `1` at an unexpected prompt keeps
+/// the tasks rather than destroys them. `Prompter::choose` is reused as-is
+/// rather than growing a `confirm` method: a yes/no question is a two-option
+/// choice, and reusing it means `StdinPrompter`'s non-interactive detection,
+/// input parsing, and range checking all apply here for free.
+pub fn confirm_flush(prompter: &mut dyn Prompter, pending: usize) -> Result<bool, PromptError> {
+    let message =
+        format!("Permanently remove {pending} soft-deleted task(s)? This cannot be undone.");
+    let options = vec![
+        "No, keep them".to_string(),
+        "Yes, permanently remove them".to_string(),
+    ];
+    Ok(prompter.choose(&message, &options)? == 1)
 }
 
 #[cfg(test)]
@@ -402,14 +578,253 @@ mod tests {
         let live_id = add(storage, "Walk dog", 0, Priority::Medium);
         manager.delete_task(deleted_id).unwrap();
 
+        // The flush reports the tasks it destroyed, not just how many
+        // (issue #32) - nobody can go and look afterwards.
         let purged = manager.flush_deleted().unwrap();
-        assert_eq!(purged, 1);
+        assert_eq!(purged.len(), 1);
+        assert_eq!(purged[0].id, deleted_id);
+        assert_eq!(purged[0].title, "Buy milk");
 
         assert!(storage.get_task(deleted_id).unwrap().is_none());
         assert!(storage.get_task(live_id).unwrap().is_some());
 
         // Nothing left to flush the second time.
-        assert_eq!(manager.flush_deleted().unwrap(), 0);
+        assert!(manager.flush_deleted().unwrap().is_empty());
+    }
+
+    /// Backdates an existing task's deletion timestamp, so tests can tell
+    /// apart deletions that would otherwise land in the same instant.
+    fn backdate_deletion(storage: &dyn Storage, task_id: u64, days: i64) {
+        let mut task = storage.get_task(task_id).unwrap().unwrap();
+        task.deleted_at = Some(chrono::Utc::now() - chrono::Duration::days(days));
+        storage.update_task(task).unwrap();
+    }
+
+    #[test]
+    fn list_deleted_returns_only_deleted_tasks_oldest_first() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        let recent = add(storage, "Buy milk", 0, Priority::Medium);
+        let ancient = add(storage, "Walk dog", 0, Priority::Medium);
+        let live = add(storage, "Still here", 0, Priority::Medium);
+        manager.delete_task(recent).unwrap();
+        manager.delete_task(ancient).unwrap();
+        backdate_deletion(storage, ancient, 30);
+
+        let listed = manager.list_deleted().unwrap();
+        assert_eq!(listed.len(), 2);
+        // Oldest deletion first: those are the ones a flush - and the
+        // age-gated automatic purge - reaches first.
+        assert_eq!(listed[0].id, ancient);
+        assert_eq!(listed[1].id, recent);
+        assert!(!listed.iter().any(|t| t.id == live));
+    }
+
+    #[test]
+    fn list_deleted_is_empty_when_nothing_has_been_deleted() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        add(storage, "Buy milk", 0, Priority::Medium);
+
+        assert!(manager.list_deleted().unwrap().is_empty());
+    }
+
+    #[test]
+    fn resolve_deleted_task_matches_by_title_then_by_id() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        let id = add(storage, "Buy milk", 0, Priority::Medium);
+        manager.delete_task(id).unwrap();
+
+        let mut prompter = ScriptedPrompter::new(vec![]);
+        let by_name = manager
+            .resolve_deleted_task("Buy milk", &mut prompter)
+            .unwrap();
+        assert_eq!(by_name.id, id);
+
+        let by_id = manager
+            .resolve_deleted_task(&id.to_string(), &mut prompter)
+            .unwrap();
+        assert_eq!(by_id.id, id);
+    }
+
+    #[test]
+    fn resolve_deleted_task_never_matches_a_live_task() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        let live = add(storage, "Buy milk", 0, Priority::Medium);
+        let mut prompter = ScriptedPrompter::new(vec![]);
+
+        // This is the inverse of `resolve_task`'s scope: a live task is not
+        // restorable, by either of its handles.
+        assert!(matches!(
+            manager
+                .resolve_deleted_task("Buy milk", &mut prompter)
+                .unwrap_err(),
+            TaskManagerError::NotFound(_)
+        ));
+        assert!(matches!(
+            manager
+                .resolve_deleted_task(&live.to_string(), &mut prompter)
+                .unwrap_err(),
+            TaskManagerError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn resolve_deleted_task_ignores_a_live_namesake_of_a_deleted_task() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        add_categories(storage, &["Work", "Home"]);
+        let deleted = add(storage, "Buy milk", 1, Priority::Medium);
+        let _live_namesake = add(storage, "Buy milk", 2, Priority::Medium);
+        manager.delete_task(deleted).unwrap();
+
+        // Only one of the two is deleted, so this is unambiguous and must
+        // not prompt - the live namesake is simply not a candidate.
+        let mut prompter = ScriptedPrompter::new(vec![]);
+        let resolved = manager
+            .resolve_deleted_task("Buy milk", &mut prompter)
+            .unwrap();
+        assert_eq!(resolved.id, deleted);
+    }
+
+    #[test]
+    fn resolve_deleted_task_prompts_when_the_title_is_ambiguous() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        add_categories(storage, &["Work", "Home"]);
+        let work = add(storage, "Buy milk", 1, Priority::Medium);
+        let home = add(storage, "Buy milk", 2, Priority::Medium);
+        manager.delete_task(work).unwrap();
+        manager.delete_task(home).unwrap();
+        backdate_deletion(storage, work, 5);
+
+        // Same README rule as every other task command, over the deleted
+        // scope. `list_deleted`'s ordering decides what index 1 means: the
+        // backdated `work` sorts first, so the scripted answer picks `home`.
+        let mut prompter = ScriptedPrompter::new(vec![Ok(1)]);
+        let resolved = manager
+            .resolve_deleted_task("Buy milk", &mut prompter)
+            .unwrap();
+        assert_eq!(resolved.id, home);
+    }
+
+    #[test]
+    fn resolve_deleted_task_propagates_non_interactive_prompt_error() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        let first = add(storage, "Buy milk", 0, Priority::Medium);
+        let second = add(storage, "Buy milk", 0, Priority::Low);
+        manager.delete_task(first).unwrap();
+        manager.delete_task(second).unwrap();
+
+        let mut prompter = ScriptedPrompter::new(vec![Err(PromptError::NotInteractive)]);
+        let err = manager
+            .resolve_deleted_task("Buy milk", &mut prompter)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            TaskManagerError::Prompt(PromptError::NotInteractive)
+        ));
+    }
+
+    #[test]
+    fn resolve_deleted_task_not_found_is_a_clean_error() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        let mut prompter = ScriptedPrompter::new(vec![]);
+
+        let err = manager
+            .resolve_deleted_task("Nope", &mut prompter)
+            .unwrap_err();
+        assert!(matches!(err, TaskManagerError::NotFound(_)));
+    }
+
+    #[test]
+    fn restore_task_returns_it_to_its_original_category_and_to_listings() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        add_categories(storage, &["Work"]);
+        let id = add(storage, "Buy milk", 1, Priority::High);
+        manager.delete_task(id).unwrap();
+        assert!(manager.list_tasks(None, false, None).unwrap().is_empty());
+
+        let mut prompter = ScriptedPrompter::new(vec![]);
+        let task = manager
+            .resolve_deleted_task("Buy milk", &mut prompter)
+            .unwrap();
+        let destination = manager.restore_task(task).unwrap();
+
+        // Lossless: same category it was deleted from (issue #29's design
+        // is what makes this free), and the priority survives too.
+        assert_eq!(destination, 1);
+        let restored = storage.get_task(id).unwrap().unwrap();
+        assert!(!restored.is_deleted());
+        assert_eq!(restored.category_id, 1);
+        assert_eq!(restored.priority, Priority::High);
+
+        // Visible to `list` again, and gone from the deleted set - so a
+        // later flush can no longer destroy it.
+        let listed = manager.list_tasks(None, false, None).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, id);
+        assert!(manager.list_deleted().unwrap().is_empty());
+        assert!(manager.flush_deleted().unwrap().is_empty());
+    }
+
+    #[test]
+    fn restore_task_leaves_an_uncategorized_task_uncategorized() {
+        let test_storage = TestStorage::new();
+        let storage = test_storage.storage();
+        let manager = TaskManager::new(storage);
+        let id = add(storage, "Buy milk", UNCATEGORIZED_ID, Priority::Medium);
+        manager.delete_task(id).unwrap();
+
+        // Uncategorized is synthesized rather than stored, so a naive
+        // "does this category exist?" check would wrongly treat it as gone.
+        let task = storage.get_task(id).unwrap().unwrap();
+        assert_eq!(manager.restore_task(task).unwrap(), UNCATEGORIZED_ID);
+    }
+
+    #[test]
+    fn restore_destination_falls_back_to_uncategorized_when_the_category_is_gone() {
+        // The category still exists: the task goes back exactly where it was.
+        assert_eq!(restore_destination(7, true), 7);
+        // It doesn't: Uncategorized, the one category that cannot be deleted,
+        // rather than a dangling reference or a refused restore.
+        assert_eq!(restore_destination(7, false), UNCATEGORIZED_ID);
+    }
+
+    #[test]
+    fn confirm_flush_requires_an_explicit_yes() {
+        // Option 1 ("No, keep them") is offered first on purpose, so a
+        // reflexive `1` at an unexpected prompt keeps the tasks.
+        let mut declined = ScriptedPrompter::new(vec![Ok(0)]);
+        assert_eq!(confirm_flush(&mut declined, 3), Ok(false));
+
+        let mut confirmed = ScriptedPrompter::new(vec![Ok(1)]);
+        assert_eq!(confirm_flush(&mut confirmed, 3), Ok(true));
+    }
+
+    #[test]
+    fn confirm_flush_reports_a_non_interactive_terminal_rather_than_assuming_yes() {
+        // The CLI turns this into a refusal to flush (`CliError::FlushNotConfirmed`);
+        // what matters here is that "nobody to ask" is never silently "yes".
+        let mut prompter = ScriptedPrompter::new(vec![Err(PromptError::NotInteractive)]);
+        assert_eq!(
+            confirm_flush(&mut prompter, 1),
+            Err(PromptError::NotInteractive)
+        );
     }
 
     #[test]

--- a/tests/category_commands.rs
+++ b/tests/category_commands.rs
@@ -97,7 +97,7 @@ fn category_lifecycle() {
     assert!(out.contains("2: Personal"), "{out}");
     assert!(!out.contains("Home"), "{out}");
 
-    // Delete frees the ID again (issue #16)
+    // Delete frees the ID again
     trtodo.ok(&["category", "delete", "Work"]);
     let out = trtodo.ok(&["category", "add", "Errands"]);
     assert!(out.contains("added with ID 1"), "{out}");

--- a/tests/config_commands.rs
+++ b/tests/config_commands.rs
@@ -1,5 +1,5 @@
-//! End-to-end coverage of `trtodo config ...`, for issue #22 ("Config
-//! defaults are declared but never applied").
+//! End-to-end coverage of `trtodo config ...`, pinning down that declared
+//! config defaults are actually applied.
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, and
 //! `$HOME` is pointed at a path that doesn't exist, so the real
@@ -82,7 +82,7 @@ fn find<'a>(entries: &'a [(String, String, bool)], key: &str) -> &'a (String, St
 
 /// A fresh install (no config file ever written) must report the README's
 /// documented defaults, each marked with `*` - not `null`. This is the
-/// primary regression test for issue #22.
+/// primary regression test for defaults being declared but never applied.
 #[test]
 fn fresh_install_reports_documented_defaults() {
     let trtodo = Trtodo::new();
@@ -119,7 +119,7 @@ fn fresh_install_reports_documented_defaults() {
     );
 }
 
-/// Regression test for issue #22's second, easier-to-miss half: once the
+/// Regression test for the second, easier-to-miss half of that bug: once the
 /// config file exists (because *one* key was set), every *other* key must
 /// still report as a default on the next invocation - not as an explicit
 /// `null`. A `Default` impl alone fixes the fresh-install case above but not

--- a/tests/deleted_commands.rs
+++ b/tests/deleted_commands.rs
@@ -1,6 +1,6 @@
-//! End-to-end coverage of the `trtodo deleted` namespace - `list` (issue
-//! #32), `restore` (issue #31), `flush` and its confirmation (issues #6,
-//! #32) - plus the automatic purge driven by `deleted-task-lifespan`.
+//! End-to-end coverage of the `trtodo deleted` namespace - `list`,
+//! `restore`, `flush` and its confirmation - plus the automatic purge
+//! driven by `deleted-task-lifespan`.
 //!
 //! Note that every invocation here is by definition non-interactive: the
 //! binary is spawned with `Command::output()`, so its stdin is not a
@@ -14,9 +14,9 @@
 //! `~/.config/trtodo` and the developer's actual todo data are never read or
 //! written. This mirrors `tests/task_commands.rs`/`tests/category_commands.rs`'s
 //! harness exactly - see `home_guard` below, which is the load-bearing part:
-//! a previous PR (#15) was rejected specifically because its test suite wiped
-//! the developer's real todo data, and this issue is about destroying data,
-//! so the guard is asserted on explicitly rather than just relied upon.
+//! an earlier attempt was rejected specifically because its test suite wiped
+//! the developer's real todo data, and these commands are about destroying
+//! data, so the guard is asserted on explicitly rather than just relied upon.
 
 use std::path::Path;
 use std::process::Command;
@@ -217,7 +217,7 @@ fn deleted_list_shows_id_title_category_and_deletion_date() {
     assert!(out.contains("Deleted tasks:"), "{out}");
     assert!(out.contains(&format!("{id}: Buy milk")), "{out}");
     // The *real* category, by name - soft deletion keeps `category_id`
-    // intact (issue #29), which is exactly what makes the restore below
+    // intact, which is exactly what makes the restore below
     // lossless.
     assert!(out.contains("category: Work"), "{out}");
     // A deletion date in the documented format. Only the "deleted: <year>"
@@ -382,7 +382,7 @@ fn flush_reports_which_tasks_it_removed() {
     trtodo.ok(&["delete", "Walk dog", "--category", "Work"]);
 
     // A count alone leaves the user with no way to find out what they lost -
-    // the rows are gone by the time they could look (issue #32).
+    // the rows are gone by the time they could look.
     let out = trtodo.ok(&["deleted", "flush", "--yes"]);
     assert!(
         out.contains("The following 2 task(s) will be permanently removed:"),

--- a/tests/deleted_commands.rs
+++ b/tests/deleted_commands.rs
@@ -1,5 +1,13 @@
-//! End-to-end coverage of `trtodo deleted flush` and the automatic purge
-//! driven by `deleted-task-lifespan` (issue #6).
+//! End-to-end coverage of the `trtodo deleted` namespace - `list` (issue
+//! #32), `restore` (issue #31), `flush` and its confirmation (issues #6,
+//! #32) - plus the automatic purge driven by `deleted-task-lifespan`.
+//!
+//! Note that every invocation here is by definition non-interactive: the
+//! binary is spawned with `Command::output()`, so its stdin is not a
+//! terminal and `StdinPrompter` returns `PromptError::NotInteractive` for
+//! any prompt. That is not an obstacle to work around, it is the scripted
+//! case these tests exist to pin down - `flush` must refuse without `--yes`,
+//! and an ambiguous `restore` must fail cleanly rather than hang.
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, and
 //! that config points `storage.path` at the same `TempDir`, so the real
@@ -79,6 +87,20 @@ impl Trtodo {
         );
         String::from_utf8(output.stdout).unwrap()
     }
+
+    /// Runs a command that is expected to fail, returning its stderr. The
+    /// counterpart to `ok` for the paths that must refuse rather than act -
+    /// `flush` with nobody to confirm at, an ambiguous `restore`, and so on.
+    fn err(&self, args: &[&str]) -> String {
+        let output = self.run(args);
+        assert!(
+            !output.status.success(),
+            "command {:?} unexpectedly succeeded: {}",
+            args,
+            String::from_utf8_lossy(&output.stdout)
+        );
+        String::from_utf8(output.stderr).unwrap()
+    }
 }
 
 #[test]
@@ -92,11 +114,11 @@ fn flush_permanently_removes_a_deleted_task() {
     let out = trtodo.ok(&["list"]);
     assert!(!out.contains("Buy milk"), "{out}");
 
-    let out = trtodo.ok(&["deleted", "flush"]);
+    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
     assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
 
     // A second flush finds nothing left to purge.
-    let out = trtodo.ok(&["deleted", "flush"]);
+    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
     assert!(out.contains("Flushed 0 deleted task(s)"), "{out}");
 
     // trtodo must never have created its own data under the guarded $HOME.
@@ -112,6 +134,9 @@ fn flush_with_nothing_deleted_is_a_clean_no_op() {
     trtodo.ok(&["category", "add", "Work"]);
     trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
 
+    // Deliberately *without* `--yes`: with nothing at stake there is nothing
+    // to confirm, so a flush of an empty deleted set stays a clean no-op
+    // even with no terminal attached.
     let out = trtodo.ok(&["deleted", "flush"]);
     assert!(out.contains("Flushed 0 deleted task(s)"), "{out}");
 
@@ -130,7 +155,7 @@ fn flush_does_not_touch_live_tasks() {
     trtodo.ok(&["add", "Walk dog", "--category", "Work"]);
     trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
 
-    trtodo.ok(&["deleted", "flush"]);
+    trtodo.ok(&["deleted", "flush", "--yes"]);
 
     let out = trtodo.ok(&["list"]);
     assert!(out.contains("Walk dog"), "{out}");
@@ -166,8 +191,262 @@ fn default_lifespan_of_zero_never_auto_purges() {
     // The task is still physically present in storage - if the automatic
     // sweep had wrongly purged it under the default threshold, this flush
     // would report 0 instead of 1.
-    let out = trtodo.ok(&["deleted", "flush"]);
+    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
     assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn deleted_list_shows_id_title_category_and_deletion_date() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    let added = trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+
+    // The ID the task was given, so the listing can be checked to report the
+    // real one rather than a position in a list.
+    let id = added
+        .split("with ID ")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .expect("add should report the new task's ID")
+        .to_string();
+
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert!(out.contains("Deleted tasks:"), "{out}");
+    assert!(out.contains(&format!("{id}: Buy milk")), "{out}");
+    // The *real* category, by name - soft deletion keeps `category_id`
+    // intact (issue #29), which is exactly what makes the restore below
+    // lossless.
+    assert!(out.contains("category: Work"), "{out}");
+    // A deletion date in the documented format. Only the "deleted: <year>"
+    // prefix is asserted on, so this doesn't turn into a clock test.
+    assert!(out.contains("deleted: 20"), "{out}");
+
+    // Still hidden from the ordinary listing and search, as before.
+    let out = trtodo.ok(&["list"]);
+    assert!(!out.contains("Buy milk"), "{out}");
+    let out = trtodo.ok(&["list", "--search", "milk"]);
+    assert!(!out.contains("Buy milk"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn deleted_list_says_so_explicitly_when_there_is_nothing_deleted() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+
+    // "A flush would destroy nothing" has to be said out loud: silence here
+    // is indistinguishable from a command that failed to look.
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert!(out.contains("Deleted tasks:"), "{out}");
+    assert!(out.contains("(none)"), "{out}");
+    assert!(!out.contains("Buy milk"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn restore_returns_a_task_to_its_original_category() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+
+    let out = trtodo.ok(&["deleted", "restore", "Buy milk"]);
+    assert!(out.contains("Task 'Buy milk' restored"), "{out}");
+    assert!(out.contains("Work"), "{out}");
+
+    // Back in the listing, in the category it was deleted from.
+    let out = trtodo.ok(&["list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+    assert!(out.contains("category: Work"), "{out}");
+
+    // And out of the deleted set, so a later flush can't destroy it.
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert!(out.contains("(none)"), "{out}");
+    let out = trtodo.ok(&["deleted", "flush"]);
+    assert!(out.contains("Flushed 0 deleted task(s)"), "{out}");
+
+    // A restored task is an ordinary task again: operable by name, and
+    // re-deletable.
+    trtodo.ok(&["check", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn restore_accepts_the_id_from_deleted_list() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    let added = trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+
+    let id = added
+        .split("with ID ")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .expect("add should report the new task's ID")
+        .to_string();
+
+    let out = trtodo.ok(&["deleted", "restore", &id]);
+    assert!(out.contains("Task 'Buy milk' restored"), "{out}");
+
+    let out = trtodo.ok(&["list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn restore_refuses_a_live_task() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+
+    // Restore searches only soft-deleted tasks - the inverse of every other
+    // task command's scope - so a perfectly good live task is "not found"
+    // here rather than being silently touched.
+    let err = trtodo.err(&["deleted", "restore", "Buy milk"]);
+    assert!(err.contains("no task matching 'Buy milk'"), "{err}");
+
+    let out = trtodo.ok(&["list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn restore_of_an_ambiguous_title_fails_cleanly_with_no_terminal_attached() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["category", "add", "Home"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Home"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Home"]);
+
+    // Two deleted tasks share the title, and there is no terminal to ask
+    // which one. The README's disambiguation rule turns into a typed error
+    // instead of a hang - and the advice is to use an ID, which
+    // `deleted list` prints.
+    let err = trtodo.err(&["deleted", "restore", "Buy milk"]);
+    assert!(err.contains("no terminal is attached"), "{err}");
+
+    // Neither task was restored, and both are still there to be rescued.
+    let out = trtodo.ok(&["list"]);
+    assert!(!out.contains("Buy milk"), "{out}");
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert_eq!(out.matches("Buy milk").count(), 2, "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn flush_refuses_to_destroy_anything_without_confirmation() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+
+    // Non-interactive (spawned with no terminal on stdin) and no `--yes`:
+    // the deliberate choice is to refuse rather than destroy data
+    // unattended, and to name the escape hatch in the error.
+    let err = trtodo.err(&["deleted", "flush"]);
+    assert!(err.contains("--yes"), "{err}");
+    assert!(err.contains("deleted list"), "{err}");
+
+    // Nothing was destroyed, so the task is still there to restore.
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+    trtodo.ok(&["deleted", "restore", "Buy milk"]);
+    let out = trtodo.ok(&["list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn flush_reports_which_tasks_it_removed() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["add", "Walk dog", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Walk dog", "--category", "Work"]);
+
+    // A count alone leaves the user with no way to find out what they lost -
+    // the rows are gone by the time they could look (issue #32).
+    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
+    assert!(
+        out.contains("The following 2 task(s) will be permanently removed:"),
+        "{out}"
+    );
+    assert!(out.contains("Buy milk"), "{out}");
+    assert!(out.contains("Walk dog"), "{out}");
+    assert!(out.contains("category: Work"), "{out}");
+    assert!(out.contains("Flushed 2 deleted task(s)"), "{out}");
+
+    // Gone for good: nothing left to list or restore.
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert!(out.contains("(none)"), "{out}");
+    let err = trtodo.err(&["deleted", "restore", "Buy milk"]);
+    assert!(err.contains("no task matching 'Buy milk'"), "{err}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn flush_accepts_force_as_an_alias_for_yes() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+
+    // `--force` and `-y` are the conventional spellings of the same escape
+    // hatch; scripts shouldn't have to guess which one this CLI chose.
+    let out = trtodo.ok(&["deleted", "flush", "--force"]);
+    assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
+
+    trtodo.ok(&["add", "Walk dog", "--category", "Work"]);
+    trtodo.ok(&["delete", "Walk dog", "--category", "Work"]);
+    let out = trtodo.ok(&["deleted", "flush", "-y"]);
+    assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
+
+    assert!(!trtodo.app_home_marker().exists());
+}
+
+#[test]
+fn deleted_commands_survive_a_category_deletion() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+
+    // Deleting the category reassigns every task in it - soft-deleted ones
+    // included - to Uncategorized, so the restore below is still well
+    // defined and lands somewhere real.
+    trtodo.ok(&["category", "delete", "Work"]);
+
+    let out = trtodo.ok(&["deleted", "list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+    assert!(out.contains("category: Uncategorized"), "{out}");
+
+    let out = trtodo.ok(&["deleted", "restore", "Buy milk"]);
+    assert!(out.contains("Uncategorized"), "{out}");
+    // Not the "original category no longer exists" wording: as far as the
+    // task is concerned Uncategorized *is* its category by this point.
+    assert!(!out.contains("no longer exists"), "{out}");
+
+    let out = trtodo.ok(&["list"]);
+    assert!(out.contains("Buy milk"), "{out}");
+    assert!(out.contains("category: Uncategorized"), "{out}");
 
     assert!(!trtodo.app_home_marker().exists());
 }

--- a/tests/first_run.rs
+++ b/tests/first_run.rs
@@ -1,0 +1,230 @@
+//! End-to-end coverage of the first-run offer to create the default "Home"
+//! and "Work" categories (issue #27, the last open bullet of issue #4).
+//!
+//! Every invocation is pointed at a `--config` file inside a `TempDir`, with
+//! `storage.path` pointing at that same `TempDir` and `$HOME` pointing at a
+//! path that does not exist, so the real `~/.config/trtodo` is never read or
+//! written - which matters more here than anywhere else, since this is the
+//! one feature whose whole job is to write to a *fresh* install.
+//!
+//! `cargo test` runs the binary with a piped stdin, so there is never a
+//! terminal attached: every test here exercises a path that must not block.
+//! The interactive answer itself is supplied by `--yes` / `--no-input`
+//! (`StdinPrompter`'s own y/n parsing is unit-tested in `src/prompter.rs`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+struct Trtodo {
+    _dir: TempDir,
+    config_path: PathBuf,
+    data_dir: PathBuf,
+}
+
+impl Trtodo {
+    /// A fresh install: a config file that only says where task data lives,
+    /// and no task data of any kind yet.
+    fn new() -> Self {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("trtodo-config.json");
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let this = Self {
+            config_path,
+            data_dir,
+            _dir: dir,
+        };
+        // `config set` is itself a command that never opens task storage, so
+        // this setup step cannot trigger the offer it is setting up for.
+        this.ok(&[
+            "config",
+            "set",
+            &format!("storage.path={}", this.data_dir.display()),
+        ]);
+        this
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+            .arg("--config")
+            .arg(&self.config_path)
+            // Make sure nothing can silently fall back to a real home directory.
+            .env("HOME", Path::new("/nonexistent-trtodo-test-home"))
+            .args(args)
+            .output()
+            .expect("failed to run trtodo")
+    }
+
+    fn ok(&self, args: &[&str]) -> String {
+        let output = self.run(args);
+        assert!(
+            output.status.success(),
+            "command {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap()
+    }
+
+    /// The JSON data file the default backend writes to. Its *absence* is
+    /// the strongest available assertion that a command left task storage
+    /// completely alone.
+    fn data_file(&self) -> PathBuf {
+        self.data_dir.join("trtodo-data.json")
+    }
+
+    /// Whether the first-run offer has been recorded as resolved. Read
+    /// straight from the config file rather than through the CLI: the marker
+    /// is deliberately not a user-facing config key, so `config list` cannot
+    /// (and should not) show it.
+    fn offer_recorded(&self) -> bool {
+        let contents = std::fs::read_to_string(&self.config_path).unwrap_or_default();
+        let config: serde_json::Value = serde_json::from_str(&contents).unwrap_or_default();
+        config
+            .get("default_categories_offered")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    /// The category names `category list` reports, minus the synthesized
+    /// "Uncategorized" entry that is always present.
+    fn real_categories(&self) -> Vec<String> {
+        self.ok(&["category", "list"])
+            .lines()
+            .filter_map(|line| line.split_once(": "))
+            .map(|(_, name)| name.trim_end_matches(" (current)").to_string())
+            .filter(|name| name != "Uncategorized")
+            .collect()
+    }
+}
+
+/// Accepting the offer creates exactly the two documented categories, and
+/// only ever once: a second run must not re-offer (which would fail outright
+/// on the duplicate-name check) or create anything more.
+#[test]
+fn accepting_creates_home_and_work_exactly_once() {
+    let trtodo = Trtodo::new();
+    assert!(!trtodo.offer_recorded());
+
+    let out = trtodo.ok(&["--yes", "category", "list"]);
+    assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
+    assert!(out.contains("Category 'Work' added with ID 2"), "{out}");
+    assert!(trtodo.offer_recorded());
+
+    // Every subsequent run - with or without `--yes` - is a no-op.
+    let out = trtodo.ok(&["--yes", "category", "list"]);
+    assert!(!out.contains("added with ID"), "{out}");
+    assert_eq!(trtodo.real_categories(), vec!["Home", "Work"]);
+}
+
+/// Declining creates neither category, and is a real answer: it is recorded,
+/// so no later run asks again - not even one that would have said yes.
+#[test]
+fn declining_creates_nothing_and_is_never_asked_again() {
+    let trtodo = Trtodo::new();
+
+    let out = trtodo.ok(&["--no-input", "category", "list"]);
+    assert!(!out.contains("added with ID"), "{out}");
+    assert!(out.contains("add categories yourself"), "{out}");
+    assert!(trtodo.offer_recorded());
+
+    assert!(trtodo.real_categories().is_empty());
+    trtodo.ok(&["--yes", "list"]);
+    assert!(trtodo.real_categories().is_empty());
+}
+
+/// With no terminal attached and no flag saying what to assume, there is
+/// nobody to ask: the command must run to completion without blocking,
+/// without creating categories, and without printing anything about the
+/// offer (a script would see that message on every run until it was
+/// answered).
+///
+/// It must also not *record* the offer - nobody answered it - so the same
+/// install still gets the offer once a human runs it interactively, which
+/// the `--yes` run at the end stands in for.
+#[test]
+fn a_non_interactive_run_neither_blocks_nor_burns_the_offer() {
+    let trtodo = Trtodo::new();
+
+    let out = trtodo.ok(&["list"]);
+    assert_eq!(out, "Tasks:\n", "{out}");
+    assert!(!trtodo.offer_recorded());
+    assert!(
+        !trtodo.data_file().exists(),
+        "a first-run offer nobody could answer must not write task storage"
+    );
+
+    let out = trtodo.ok(&["--yes", "category", "list"]);
+    assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
+}
+
+/// `trtodo config ...` never opens task storage, so it must never make the
+/// offer either - creating categories from a read-only config query would
+/// write a data file (and its directory) as a side effect, and offering
+/// during `config set storage.path=...` would put the new categories in the
+/// location the user is in the middle of moving away from.
+#[test]
+fn config_commands_never_trigger_the_offer() {
+    let trtodo = Trtodo::new();
+
+    trtodo.ok(&["config", "list"]);
+    trtodo.ok(&["--yes", "config", "list"]);
+    trtodo.ok(&["--yes", "config", "set", "default-priority=high"]);
+
+    assert!(!trtodo.offer_recorded());
+    assert!(!trtodo.data_file().exists());
+
+    // The offer is not lost, just deferred to the first command that
+    // actually touches task storage.
+    let out = trtodo.ok(&["--yes", "category", "list"]);
+    assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
+}
+
+/// An install that already has categories is not a fresh one, so it is never
+/// interrupted by the offer - and the offer is quietly marked resolved, which
+/// is what keeps "the user deliberately deleted every category" from looking
+/// like a fresh install later on.
+#[test]
+fn existing_categories_mean_this_is_not_a_first_run() {
+    let trtodo = Trtodo::new();
+
+    // Created by a non-interactive run, so nothing has been offered or
+    // recorded yet - only this one category exists.
+    trtodo.ok(&["category", "add", "Errands"]);
+    assert!(!trtodo.offer_recorded());
+
+    let out = trtodo.ok(&["--yes", "category", "list"]);
+    assert!(!out.contains("added with ID"), "{out}");
+    assert_eq!(trtodo.real_categories(), vec!["Errands"]);
+    assert!(trtodo.offer_recorded());
+}
+
+/// Deleting every category is a legitimate empty state, not a reinstall: the
+/// recorded marker means it is never mistaken for one.
+#[test]
+fn deleting_every_category_does_not_re_offer() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["--yes", "category", "list"]);
+
+    trtodo.ok(&["category", "delete", "Home"]);
+    trtodo.ok(&["category", "delete", "Work"]);
+    assert!(trtodo.real_categories().is_empty());
+
+    let out = trtodo.ok(&["--yes", "category", "list"]);
+    assert!(!out.contains("added with ID"), "{out}");
+    assert!(trtodo.real_categories().is_empty());
+}
+
+/// The offer works the same way against the SQLite backend - it goes through
+/// `CategoryManager`, not any backend-specific path.
+#[test]
+fn the_offer_is_backend_agnostic() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+
+    let out = trtodo.ok(&["--yes", "category", "list"]);
+    assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
+    assert_eq!(trtodo.real_categories(), vec!["Home", "Work"]);
+}

--- a/tests/first_run.rs
+++ b/tests/first_run.rs
@@ -1,5 +1,5 @@
 //! End-to-end coverage of the first-run offer to create the default "Home"
-//! and "Work" categories (issue #27, the last open bullet of issue #4).
+//! and "Work" categories.
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, with
 //! `storage.path` pointing at that same `TempDir` and `$HOME` pointing at a

--- a/tests/storage_backend_switch.rs
+++ b/tests/storage_backend_switch.rs
@@ -1,7 +1,7 @@
-//! End-to-end coverage of `trtodo config set storage.type=...`, for issue #17.
+//! End-to-end coverage of `trtodo config set storage.type=...`.
 //!
-//! The residue of that issue, once the original "file is not a database" panic
-//! was gone, was this: each backend keeps its own data file, so changing
+//! Once the original "file is not a database" panic was gone, this was what
+//! remained: each backend keeps its own data file, so changing
 //! `storage.type` made every category and task vanish from view. Nothing was
 //! destroyed - the old file sat there untouched and switching back revealed it
 //! again - but the only explanation offered was "Warning: Changing storage

--- a/tests/storage_backend_switch.rs
+++ b/tests/storage_backend_switch.rs
@@ -1,0 +1,291 @@
+//! End-to-end coverage of `trtodo config set storage.type=...`, for issue #17.
+//!
+//! The residue of that issue, once the original "file is not a database" panic
+//! was gone, was this: each backend keeps its own data file, so changing
+//! `storage.type` made every category and task vanish from view. Nothing was
+//! destroyed - the old file sat there untouched and switching back revealed it
+//! again - but the only explanation offered was "Warning: Changing storage
+//! type may require data migration", naming a migration that did not exist.
+//!
+//! These tests pin the three outcomes a switch can now have: carry the data
+//! across, refuse to clobber a destination that already has data (and say so),
+//! or stay quiet because there was nothing to carry.
+//!
+//! Every invocation is pointed at a `--config` file inside a `TempDir` with
+//! `storage.path` pointing into the same `TempDir`, and `$HOME` at a path that
+//! does not exist, so the real `~/.config/trtodo` is never read or written.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+struct Trtodo {
+    _dir: TempDir,
+    config_path: PathBuf,
+    data_dir: PathBuf,
+}
+
+impl Trtodo {
+    fn new() -> Self {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("trtodo-config.json");
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let this = Self {
+            config_path,
+            data_dir,
+            _dir: dir,
+        };
+        this.ok(&[
+            "config",
+            "set",
+            &format!("storage.path={}", this.data_dir.display()),
+        ]);
+        this
+    }
+
+    fn run(&self, args: &[&str]) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+            .arg("--config")
+            .arg(&self.config_path)
+            // Make sure nothing can silently fall back to a real home directory.
+            .env("HOME", Path::new("/nonexistent-trtodo-test-home"))
+            .args(args)
+            .output()
+            .expect("failed to run trtodo")
+    }
+
+    fn ok(&self, args: &[&str]) -> String {
+        let output = self.run(args);
+        assert!(
+            output.status.success(),
+            "command {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap()
+    }
+
+    /// Both streams of a successful command: the switch reports a migration on
+    /// stdout but warns about a refused one on stderr, and tests here care
+    /// about each independently.
+    fn ok_both(&self, args: &[&str]) -> (String, String) {
+        let output = self.run(args);
+        assert!(
+            output.status.success(),
+            "command {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        (
+            String::from_utf8(output.stdout).unwrap(),
+            String::from_utf8(output.stderr).unwrap(),
+        )
+    }
+
+    fn json_file(&self) -> PathBuf {
+        self.data_dir.join("trtodo-data.json")
+    }
+
+    fn sqlite_file(&self) -> PathBuf {
+        self.data_dir.join("trtodo-data.db")
+    }
+
+    /// Seeds a category, a task in it, and a `category use` context - the
+    /// smallest set of state that would be visibly "lost" by a switch.
+    fn seed(&self) {
+        self.ok(&["category", "add", "Work"]);
+        self.ok(&["add", "--category", "Work", "Finish report"]);
+        self.ok(&["category", "use", "Work"]);
+    }
+}
+
+/// The headline fix: switching from JSON to SQLite carries the user's data
+/// across instead of stranding it, and says so plainly.
+#[test]
+fn switching_backend_carries_existing_data_across() {
+    let trtodo = Trtodo::new();
+    trtodo.seed();
+
+    let json_before = std::fs::read_to_string(trtodo.json_file()).unwrap();
+    assert!(json_before.contains("Finish report"));
+
+    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=sqlite"]);
+    assert!(
+        stdout.contains("Migrated 1 task(s) and 1 category from json to sqlite"),
+        "expected an accurate migration report, got stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(&trtodo.json_file().display().to_string()),
+        "the user should be told exactly where their previous data still lives, got: {stdout}"
+    );
+    // The old "may require data migration" hedge is gone: a migration either
+    // happened or it didn't, and this one did.
+    assert!(
+        !stderr.contains("may require data migration"),
+        "the vague unconditional warning should be gone, got stderr: {stderr}"
+    );
+
+    // The data is genuinely there under the new backend...
+    let categories = trtodo.ok(&["category", "list"]);
+    assert!(categories.contains("Work"), "{categories}");
+    let tasks = trtodo.ok(&["list"]);
+    assert!(tasks.contains("Finish report"), "{tasks}");
+    // ... including the `category use` context.
+    assert!(
+        categories.contains("Work (current)"),
+        "the category context should survive the switch, got: {categories}"
+    );
+
+    // ... and the switch was non-destructive: the JSON file is byte-for-byte
+    // what it was.
+    assert_eq!(
+        std::fs::read_to_string(trtodo.json_file()).unwrap(),
+        json_before,
+        "migrating must never rewrite or truncate the source store"
+    );
+    assert!(trtodo.sqlite_file().exists());
+}
+
+/// Switching back to a backend that already holds data must refuse to
+/// overwrite it, and must tell the user where the *other* set of data is and
+/// how to get back to it. Merging the two would mean renumbering IDs, which is
+/// a different feature with different risks.
+#[test]
+fn switching_back_to_a_populated_backend_refuses_to_clobber_and_says_so() {
+    let trtodo = Trtodo::new();
+    trtodo.seed();
+    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+
+    // Diverge the two stores so a clobber in either direction is detectable.
+    trtodo.ok(&["add", "--category", "Work", "Only in sqlite"]);
+
+    let json_before = std::fs::read_to_string(trtodo.json_file()).unwrap();
+    let sqlite_before = std::fs::read(trtodo.sqlite_file()).unwrap();
+
+    let (_, stderr) = trtodo.ok_both(&["config", "set", "storage.type=json"]);
+    assert!(
+        stderr.contains("json storage already holds"),
+        "the user should be told why nothing was migrated, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("nothing was overwritten"),
+        "the user should be told their data is safe, got: {stderr}"
+    );
+    assert!(
+        stderr.contains(&trtodo.sqlite_file().display().to_string())
+            && stderr.contains("storage.type=sqlite"),
+        "the user should be told where the other data is and how to reach it, got: {stderr}"
+    );
+
+    // Neither store was touched.
+    assert_eq!(
+        std::fs::read_to_string(trtodo.json_file()).unwrap(),
+        json_before
+    );
+    assert_eq!(std::fs::read(trtodo.sqlite_file()).unwrap(), sqlite_before);
+
+    // The advertised escape hatch really works: the sqlite-only task is still
+    // reachable by switching back.
+    let json_tasks = trtodo.ok(&["list"]);
+    assert!(json_tasks.contains("Finish report"), "{json_tasks}");
+    assert!(!json_tasks.contains("Only in sqlite"), "{json_tasks}");
+
+    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+    let sqlite_tasks = trtodo.ok(&["list"]);
+    assert!(sqlite_tasks.contains("Only in sqlite"), "{sqlite_tasks}");
+}
+
+/// A first-ever switch, with nothing stored yet, must be completely quiet -
+/// the old warning fired here too, worrying users about a migration of no
+/// data at all.
+#[test]
+fn switching_with_nothing_stored_is_quiet() {
+    let trtodo = Trtodo::new();
+
+    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=sqlite"]);
+    assert_eq!(stdout, "Configuration updated successfully\n", "{stdout}");
+    assert_eq!(
+        stderr, "",
+        "a switch with no data to move should say nothing"
+    );
+}
+
+/// Setting `storage.type` to the value it already has isn't a switch at all,
+/// so it must not report a migration (and must not risk writing anything).
+#[test]
+fn setting_storage_type_to_its_current_value_is_a_no_op() {
+    let trtodo = Trtodo::new();
+    trtodo.seed();
+    let json_before = std::fs::read_to_string(trtodo.json_file()).unwrap();
+
+    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=json"]);
+    assert_eq!(stdout, "Configuration updated successfully\n", "{stdout}");
+    assert_eq!(stderr, "", "{stderr}");
+    assert_eq!(
+        std::fs::read_to_string(trtodo.json_file()).unwrap(),
+        json_before
+    );
+    assert!(
+        !trtodo.sqlite_file().exists(),
+        "a no-op switch must not materialise the other backend's file"
+    );
+}
+
+/// An unrecognised backend is still rejected by config validation, and the
+/// migration hook must not get in the way of that message or leave a
+/// half-created store behind.
+#[test]
+fn an_unknown_storage_type_is_still_rejected_cleanly() {
+    let trtodo = Trtodo::new();
+    trtodo.seed();
+
+    let output = trtodo.run(&["config", "set", "storage.type=postgres"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("storage.type must be one of"),
+        "expected the config validation error, got: {stderr}"
+    );
+    assert!(!trtodo.sqlite_file().exists());
+    // The setting is unchanged, so the user is still looking at their data.
+    assert!(trtodo.ok(&["list"]).contains("Finish report"));
+}
+
+/// A store that can't be read is exactly when a user most wants to switch away
+/// from it. Blocking the switch would trap them on the broken backend - and
+/// would do it by reporting an error about the backend they were leaving, not
+/// the one they asked for. The switch must go through, with an honest note
+/// that nothing was migrated and that the file was left alone.
+#[test]
+fn an_unreadable_source_store_warns_but_does_not_block_the_switch() {
+    let trtodo = Trtodo::new();
+    trtodo.seed();
+
+    // Corrupt the JSON store behind the app's back.
+    std::fs::write(trtodo.json_file(), "{ this is not valid json").unwrap();
+    let corrupted = std::fs::read_to_string(trtodo.json_file()).unwrap();
+
+    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=sqlite"]);
+    assert!(
+        stdout.contains("Configuration updated successfully"),
+        "the switch itself must still succeed, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("could not read the existing json store")
+            && stderr.contains("nothing was migrated"),
+        "the user should be told why their data didn't come along, got: {stderr}"
+    );
+
+    // The unreadable file is left exactly as found - it is the only copy of
+    // whatever is salvageable in there.
+    assert_eq!(
+        std::fs::read_to_string(trtodo.json_file()).unwrap(),
+        corrupted
+    );
+
+    // And the new backend is usable, so the user isn't stuck.
+    trtodo.ok(&["category", "add", "Fresh"]);
+    assert!(trtodo.ok(&["category", "list"]).contains("Fresh"));
+}

--- a/tests/task_commands.rs
+++ b/tests/task_commands.rs
@@ -79,7 +79,7 @@ fn add_defaults_priority_from_config_and_lists_it() {
     trtodo.ok(&["category", "add", "Work"]);
 
     // No --priority: falls back to the configured/documented default
-    // (medium), not a hardcoded value (issue #22).
+    // (medium), not a hardcoded value.
     let out = trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
     assert!(out.contains("added with ID 1"), "{out}");
 
@@ -115,8 +115,8 @@ fn add_defaults_priority_from_config_and_lists_it() {
     );
 }
 
-/// Issue #33: `--category` is optional on `add`, and the four resolution
-/// steps must be tried in order, most specific first.
+/// `--category` is optional on `add`, and the four resolution steps must be
+/// tried in order, most specific first.
 #[test]
 fn add_resolves_its_category_in_precedence_order() {
     let trtodo = Trtodo::new();

--- a/tests/task_commands.rs
+++ b/tests/task_commands.rs
@@ -115,6 +115,125 @@ fn add_defaults_priority_from_config_and_lists_it() {
     );
 }
 
+/// Issue #33: `--category` is optional on `add`, and the four resolution
+/// steps must be tried in order, most specific first.
+#[test]
+fn add_resolves_its_category_in_precedence_order() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["category", "add", "Home"]);
+    trtodo.ok(&["category", "add", "Errands"]);
+
+    // Step 4: nothing set at all - no --category, no context, no
+    // default-category - so the task is simply uncategorized rather than an
+    // error.
+    let out = trtodo.ok(&["add", "Loose task"]);
+    assert!(out.contains("in category 'Uncategorized'"), "{out}");
+
+    // Step 3: `default-category` now supplies it. This is the step that did
+    // not exist before - the setting was stored, validated and listed, but
+    // never read by anything.
+    trtodo.ok(&["config", "set", "default-category=Errands"]);
+    let out = trtodo.ok(&["add", "Configured task"]);
+    assert!(out.contains("in category 'Errands'"), "{out}");
+
+    // Step 2: an explicit `category use` context outranks the configured
+    // default - transient intent beats persistent configuration.
+    trtodo.ok(&["category", "use", "Home"]);
+    let out = trtodo.ok(&["add", "Context task"]);
+    assert!(out.contains("in category 'Home'"), "{out}");
+
+    // Step 1: an explicit --category outranks both.
+    let out = trtodo.ok(&["add", "Explicit task", "--category", "Work"]);
+    assert!(out.contains("in category 'Work'"), "{out}");
+
+    // Clearing the context falls back to the configured default again, rather
+    // than to Uncategorized - the two settings do not consume each other.
+    trtodo.ok(&["category", "clear"]);
+    let out = trtodo.ok(&["add", "Back to default"]);
+    assert!(out.contains("in category 'Errands'"), "{out}");
+
+    // And unsetting the default falls the rest of the way to Uncategorized.
+    trtodo.ok(&["config", "default", "default-category"]);
+    let out = trtodo.ok(&["add", "Truly loose"]);
+    assert!(out.contains("in category 'Uncategorized'"), "{out}");
+
+    let out = trtodo.ok(&["list"]);
+    assert!(
+        out.contains("Loose task (priority: medium, category: Uncategorized)"),
+        "{out}"
+    );
+    assert!(
+        out.contains("Configured task (priority: medium, category: Errands)"),
+        "{out}"
+    );
+    assert!(
+        out.contains("Context task (priority: medium, category: Home)"),
+        "{out}"
+    );
+    assert!(
+        out.contains("Explicit task (priority: medium, category: Work)"),
+        "{out}"
+    );
+}
+
+/// `default-category` is stored without being validated against the category
+/// list, and a category that existed when it was set can be deleted later, so
+/// `add` has to cope with a default that does not resolve. It refuses rather
+/// than quietly filing the task under Uncategorized.
+#[test]
+fn add_errors_when_the_configured_default_category_does_not_resolve() {
+    let trtodo = Trtodo::new();
+
+    // A name that never existed - `config set` accepts it happily.
+    trtodo.ok(&["config", "set", "default-category=Ghost"]);
+    let err = trtodo.fail(&["add", "Orphaned task"]);
+    assert!(err.contains("default-category"), "{err}");
+    assert!(err.contains("Ghost"), "{err}");
+    // The message has to be actionable, since the user cannot see which of the
+    // four steps was reached.
+    assert!(err.contains("--category"), "{err}");
+
+    // Nothing was written: refusing must not half-succeed.
+    let out = trtodo.ok(&["list"]);
+    assert!(!out.contains("Orphaned task"), "{out}");
+
+    // A broken default only breaks the `add`s that actually fall through to
+    // it - an explicit --category still works.
+    trtodo.ok(&["category", "add", "Work"]);
+    let out = trtodo.ok(&["add", "Explicit task", "--category", "Work"]);
+    assert!(out.contains("in category 'Work'"), "{out}");
+
+    // ...as does a `category use` context, which is resolved one step earlier.
+    trtodo.ok(&["category", "use", "Work"]);
+    let out = trtodo.ok(&["add", "Context task"]);
+    assert!(out.contains("in category 'Work'"), "{out}");
+
+    // A default that was valid when set but whose category has since been
+    // deleted behaves the same way - which is why validating at `config set`
+    // time would not have been enough.
+    trtodo.ok(&["category", "clear"]);
+    trtodo.ok(&["category", "add", "Temporary"]);
+    trtodo.ok(&["config", "set", "default-category=Temporary"]);
+    trtodo.ok(&["add", "Fine for now"]);
+    trtodo.ok(&["category", "delete", "Temporary"]);
+    let err = trtodo.fail(&["add", "Too late"]);
+    assert!(err.contains("Temporary"), "{err}");
+}
+
+/// `default-category` may name a category by ID as well as by name, since it
+/// goes through the same resolution as `--category`.
+#[test]
+fn add_accepts_a_default_category_given_as_an_id() {
+    let trtodo = Trtodo::new();
+    let out = trtodo.ok(&["category", "add", "Work"]);
+    assert!(out.contains("added with ID 1"), "{out}");
+
+    trtodo.ok(&["config", "set", "default-category=1"]);
+    let out = trtodo.ok(&["add", "By ID"]);
+    assert!(out.contains("in category 'Work'"), "{out}");
+}
+
 #[test]
 fn add_can_target_the_uncategorized_category_by_name_or_id() {
     let trtodo = Trtodo::new();


### PR DESCRIPTION
Closes #17, #25, #27, #31, #32, #33.

## Features

| Commit | What |
| --- | --- |
| `feat(storage): migrate data when storage.type changes` | Switching backends now carries tasks and categories across instead of stranding them in a file nothing reads. Non-destructive: the source is only ever read, and a non-empty destination is refused rather than overwritten. |
| `feat(deleted): add list and restore, and confirm before flush` | Soft-deleted tasks were invisible until `flush` destroyed them. `deleted list` shows them, `deleted restore` puts one back in its original category, and `flush` previews what it will destroy and asks first. |
| `feat(add): resolve the task category from default-category config` | `--category` is now optional on `add`. Resolution runs explicit flag → `category use` context → `default-category` config → Uncategorized. |
| `feat(cli): offer the default Home and Work categories on first run` | The README's default categories are offered once, on the first run that touches task storage, and the answer is recorded so it is never asked twice. |
| `fix(storage): allow tasks in Uncategorized under the SQLite backend` | Found by testing the above against each other: Uncategorized is synthesized rather than stored, so a task in it violated the `tasks.category_id` foreign key. SQLite now seeds a sentinel row on save and filters it back out on load. |

## Housekeeping

The last three commits are independent of the features above and can be cherry-picked out if you'd rather land them separately:

- `ci: enforce Conventional Commits on pull requests` — commitlint on PR commits, plus a PR-title check, since a squash-merge makes the title the commit on `main`. Scoped to PRs so the older history isn't retroactively failed.
- `docs: drop issue references from code comments` — removes ~90 `(issue #29)` / `Issue #25:` style references. Where the number carried the sentence, the comment now states the reason directly. Comments only, no behavior change.
- `docs: add working notes on rough edges and session cost` — adds `CLAUDE.md` (architecture and the invariants that have actually caused bugs) and `docs/WORKING-NOTES.md` (known defects, build gotchas, and what wastes effort).

## Two decisions worth a second opinion

Both were left open by the issues and settled one way here:

1. An unresolvable `default-category` **errors** rather than warning and falling back to Uncategorized.
2. `deleted flush` with no terminal attached **refuses** rather than assuming yes. `--yes` is the way to script it.

## One defect found but deliberately not fixed

The README specifies the binary is `trtodo`, but `Cargo.toml` has no `[[bin]]` section, so cargo builds `trusty_rusty_todo_list`. Verified that adding the stanza fixes it and that doing so breaks `CARGO_BIN_EXE_*` in all seven test files. Left for its own commit rather than buried here; written up in `docs/WORKING-NOTES.md`.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, and 149 tests across 7 binaries all pass locally and in CI.

Hand-exercised end to end: first-run accept and decline, all four `add` resolution paths, soft-delete → `deleted list` → `restore`, and a JSON↔SQLite round trip carrying an uncategorized and a soft-deleted task (source file byte-identical afterward).

Not verified: any use against a real `$HOME`, large datasets, or non-Linux platforms.