### PR TITLE
fix(build): produce the documented trtodo binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,6 @@ Open and deliberately not started:
   checklists with an exit condition. #20's real gap is backend parity: most
   behaviour is exercised against JSON only, which is how the SQLite
   foreign-key bug shipped.
-- **#35 binary name** — the README specifies `trtodo`, `Cargo.toml` builds
-  `trusty_rusty_todo_list`. Fix is a `[[bin]]` stanza plus a rename of
-  `CARGO_BIN_EXE_*` across all seven test files.
 - **#36 category rename orphans `default-category`** — the setting stores a
   name (IDs get recycled, which is worse), and nothing keeps it in step.
 - **#37 `JsonStorage::save` has no format check** — unreachable through
@@ -156,8 +153,7 @@ Open and deliberately not started:
 ## Rough edges and session cost
 
 `docs/WORKING-NOTES.md` covers what this file deliberately leaves out: known
-defects not yet filed (the binary is built as `trusty_rusty_todo_list`, not the
-documented `trtodo`; renaming a category orphans `default-category`), build
+defects not yet filed (renaming a category orphans `default-category`), build
 facts that surprise people (`cargo test --lib` fails — there is no lib target;
 `rusqlite` is bundled, so never delete `target/`), and the practices that keep
 an AI-assisted session from spending its budget re-deriving known things.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "trtodo"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4.4.6", features = ["derive", "env"] }
 serde = { version = "1.0.188", features = ["derive"] }

--- a/docs/WORKING-NOTES.md
+++ b/docs/WORKING-NOTES.md
@@ -13,32 +13,6 @@ how to spend fewer tokens getting the same work done.
 
 ## Rough edges
 
-### The binary is not called `trtodo`
-
-`README.md` line 21 says "The binary named `trtodo`", and every row of the
-command table spells commands as `trtodo ...`. But `Cargo.toml` has no
-`[[bin]]` section, so the binary takes the package name: `cargo build`
-produces `target/debug/trusty_rusty_todo_list`.
-
-Nothing is broken by this today — the integration tests find the binary
-through `env!("CARGO_BIN_EXE_trusty_rusty_todo_list")`, which cargo generates
-from the real target name — but the documented install does not produce the
-documented command. By this repo's own rule (the README is the spec), this is
-a bug in `Cargo.toml`, not in the README.
-
-Filed as #35. The fix is one stanza plus a mechanical rename:
-
-```toml
-[[bin]]
-name = "trtodo"
-path = "src/main.rs"
-```
-
-...and then `CARGO_BIN_EXE_trusty_rusty_todo_list` → `CARGO_BIN_EXE_trtodo`
-in all seven files under `tests/`. Deliberately not done yet: it is a real
-change with a blast radius, and it deserves its own commit rather than
-riding along with unrelated work.
-
 ### Two further gaps
 
 - **Renaming a category orphans a `default-category` that names it** (#36). The
@@ -59,7 +33,7 @@ riding along with unrelated work.
 - **There is no lib target.** `cargo test --lib` fails outright with `no
   library targets found in package`. The ~99 unit tests live in the binary
   target alongside the 50 integration tests. Use plain `cargo test`, or
-  `cargo test --bin trusty_rusty_todo_list` to skip the integration suites.
+  `cargo test --bin trtodo` to skip the integration suites.
 
 - **`rusqlite` is vendored with `features = ["bundled"]`**, so a cold build
   compiles SQLite from C source and takes minutes. A warm build takes

--- a/tests/category_commands.rs
+++ b/tests/category_commands.rs
@@ -33,7 +33,7 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+        Command::new(env!("CARGO_BIN_EXE_trtodo"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.

--- a/tests/config_commands.rs
+++ b/tests/config_commands.rs
@@ -29,7 +29,7 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+        Command::new(env!("CARGO_BIN_EXE_trtodo"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.

--- a/tests/deleted_commands.rs
+++ b/tests/deleted_commands.rs
@@ -47,7 +47,7 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+        Command::new(env!("CARGO_BIN_EXE_trtodo"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.

--- a/tests/first_run.rs
+++ b/tests/first_run.rs
@@ -47,7 +47,7 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+        Command::new(env!("CARGO_BIN_EXE_trtodo"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.

--- a/tests/storage_backend_switch.rs
+++ b/tests/storage_backend_switch.rs
@@ -46,7 +46,7 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+        Command::new(env!("CARGO_BIN_EXE_trtodo"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.

--- a/tests/task_commands.rs
+++ b/tests/task_commands.rs
@@ -34,7 +34,7 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trusty_rusty_todo_list"))
+        Command::new(env!("CARGO_BIN_EXE_trtodo"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.


### PR DESCRIPTION
## Summary
- `Cargo.toml` had no `[[bin]]` section, so `cargo build` produced `target/debug/trusty_rusty_todo_list` instead of the `trtodo` binary the README documents.
- Add a `[[bin]]` stanza pinning the binary name to `trtodo`.
- Rename `CARGO_BIN_EXE_trusty_rusty_todo_list` → `CARGO_BIN_EXE_trtodo` across the 6 integration test files that shell out to the built binary.
- Update `CLAUDE.md` and `docs/WORKING-NOTES.md` to drop the now-resolved notes about this defect.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (149 tests: 99 unit + 50 across the 6 integration suites)

Closes #35

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBaCxMgN1nbGPg75qppEwy)_