### PR TITLE
fix(storage): reject a non-JSON target in JsonStorage::save

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -315,4 +315,6 @@ pub enum StorageError {
     InvalidTaskCategory(u64, u64),
     #[error("Duplicate category name: {0}")]
     DuplicateCategory(String),
+    #[error("File format mismatch: {0}")]
+    FormatMismatch(String),
 }

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -12,12 +12,60 @@ impl JsonStorage {
             path: path.as_ref().to_path_buf(),
         }
     }
+
+    /// Verifies that if a file exists at the target path and is non-empty, it
+    /// contains valid JSON and is not in SQLite format. This guard prevents
+    /// `save` from silently overwriting a SQLite database file (or any other
+    /// non-JSON file) with JSON data, losing the original contents.
+    ///
+    /// Returns `Ok(())` if the file is absent, empty, or contains valid JSON.
+    /// Returns `Err(StorageError::FormatMismatch)` if the file exists, is
+    /// non-empty, and fails format validation (SQLite magic bytes or invalid
+    /// JSON).
+    ///
+    /// This makes the guarantee local to the backend instead of depending on a
+    /// filename convention maintained elsewhere. While normal configuration
+    /// routes each backend to a distinct file (`trtodo-data.json` vs
+    /// `trtodo-data.db`), a direct `JsonStorage::new(...)` call with an
+    /// arbitrary path can reach any file. The check closes that gap.
+    fn validate_target_format(&self) -> Result<(), StorageError> {
+        if !self.path.exists() {
+            return Ok(());
+        }
+
+        // Read the file to check its format
+        let bytes = std::fs::read(&self.path)?;
+        if bytes.is_empty() {
+            return Ok(());
+        }
+
+        // SQLite database files start with this 16-byte magic header.
+        const SQLITE_MAGIC: &[u8] = b"SQLite format 3\0";
+        if bytes.len() >= SQLITE_MAGIC.len() && &bytes[..SQLITE_MAGIC.len()] == SQLITE_MAGIC {
+            return Err(StorageError::FormatMismatch(
+                "target file is a SQLite database, not JSON".to_string(),
+            ));
+        }
+
+        // Attempt to parse as JSON to confirm it's valid. If this fails, the
+        // file exists and is non-empty but is not valid JSON - reject the write.
+        let contents = String::from_utf8_lossy(&bytes);
+        serde_json::from_str::<serde_json::Value>(&contents).map_err(|_| {
+            StorageError::FormatMismatch("target file exists and is not valid JSON".to_string())
+        })?;
+
+        Ok(())
+    }
 }
 
 impl Storage for JsonStorage {
     fn save(&self, data: &StorageData) -> Result<(), StorageError> {
         // Validate data before saving
         data.validate()?;
+
+        // Check that the target file (if it exists) is in JSON format, not
+        // SQLite or some other format.
+        self.validate_target_format()?;
 
         // Create parent directories if they don't exist
         if let Some(parent) = self.path.parent() {
@@ -264,5 +312,126 @@ mod tests {
         assert_eq!(loaded.tasks.len(), 1);
         assert_eq!(loaded.tasks[0].deleted_at, None);
         assert!(!loaded.tasks[0].is_deleted());
+    }
+
+    /// Attempting to save over a file containing SQLite magic bytes must fail
+    /// gracefully with a `FormatMismatch` error rather than silently overwriting
+    /// the SQLite database and destroying the data.
+    #[test]
+    fn test_save_rejects_sqlite_magic_bytes() {
+        let dir = tempdir().unwrap();
+        let json_path = dir.path().join("sqlite.db");
+
+        // Write SQLite magic bytes to the file
+        let sqlite_magic = b"SQLite format 3\0\x04\x00\x00\x00";
+        fs::write(&json_path, sqlite_magic).unwrap();
+        let original_contents = fs::read(&json_path).unwrap();
+
+        // Attempt to save JSON data over it; this must fail
+        let storage = JsonStorage::new(&json_path);
+        let test_data = create_test_data();
+        let result = storage.save(&test_data);
+
+        // Verify we got a format mismatch error
+        assert!(result.is_err());
+        match result {
+            Err(StorageError::FormatMismatch(msg)) => {
+                assert!(msg.contains("SQLite") || msg.contains("SQLite database"));
+            }
+            other => panic!("expected FormatMismatch error, got {:?}", other),
+        }
+
+        // Verify the file was not modified
+        let current_contents = fs::read(&json_path).unwrap();
+        assert_eq!(
+            original_contents, current_contents,
+            "file should not be modified when save rejects it"
+        );
+    }
+
+    /// Saving to a nonexistent path must work normally, creating the file.
+    #[test]
+    fn test_save_to_nonexistent_path_succeeds() {
+        let dir = tempdir().unwrap();
+        let json_path = dir.path().join("nonexistent.json");
+
+        assert!(!json_path.exists());
+
+        let storage = JsonStorage::new(&json_path);
+        let test_data = create_test_data();
+        storage.save(&test_data).unwrap();
+
+        assert!(json_path.exists());
+        let loaded = storage.load().unwrap();
+        assert_eq!(loaded.tasks.len(), 2);
+        assert_eq!(loaded.categories.len(), 2);
+    }
+
+    /// Saving over an existing valid JSON file must work normally, replacing
+    /// the old content with new data.
+    #[test]
+    fn test_save_over_existing_valid_json_succeeds() {
+        let dir = tempdir().unwrap();
+        let json_path = dir.path().join("existing.json");
+
+        let storage = JsonStorage::new(&json_path);
+
+        // Save initial data
+        let initial_data = create_test_data();
+        storage.save(&initial_data).unwrap();
+        let loaded = storage.load().unwrap();
+        assert_eq!(loaded.tasks.len(), 2);
+
+        // Create new data with different content
+        let mut new_data = StorageData::new();
+        let mut category = Category::new("New".to_string(), None).unwrap();
+        category.id = 1;
+        new_data.categories.push(category.clone());
+        let mut task = Task::new("New task".to_string(), 1, None, Priority::Low).unwrap();
+        task.id = 1;
+        new_data.tasks.push(task);
+
+        // Save over the existing file - this must succeed
+        storage.save(&new_data).unwrap();
+
+        // Verify the new data was written
+        let reloaded = storage.load().unwrap();
+        assert_eq!(reloaded.tasks.len(), 1);
+        assert_eq!(reloaded.categories.len(), 1);
+        assert_eq!(reloaded.tasks[0].title, "New task");
+    }
+
+    /// Attempting to save over a file with invalid JSON (not SQLite, but also
+    /// not valid JSON) must fail gracefully without modifying the file.
+    #[test]
+    fn test_save_rejects_invalid_json() {
+        let dir = tempdir().unwrap();
+        let json_path = dir.path().join("invalid.json");
+
+        // Write some invalid JSON to the file
+        let invalid_json = b"{ this is not valid json }";
+        fs::write(&json_path, invalid_json).unwrap();
+        let original_contents = fs::read(&json_path).unwrap();
+
+        // Attempt to save JSON data over it; this must fail
+        let storage = JsonStorage::new(&json_path);
+        let test_data = create_test_data();
+        let result = storage.save(&test_data);
+
+        // Verify we got a format mismatch error
+        assert!(result.is_err());
+        match result {
+            Err(StorageError::FormatMismatch(msg)) => {
+                assert!(msg.contains("not valid JSON"));
+            }
+            other => panic!("expected FormatMismatch error, got {:?}", other),
+        }
+
+        // Verify the file was not modified
+        let current_contents = fs::read(&json_path).unwrap();
+        assert_eq!(
+            original_contents, current_contents,
+            "file should not be modified when save rejects it"
+        );
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -811,6 +811,55 @@ mod tests {
         );
     }
 
+    /// The mirror-image direction: attempting to save JSON data over an existing
+    /// SQLite database file must fail gracefully and not clobber the original.
+    /// This direction was not checked at the storage layer before - it relied on
+    /// distinct filenames in configuration to remain unreachable. This test pins
+    /// the protection added to `JsonStorage::save`.
+    #[test]
+    fn test_json_rejects_sqlite_populated_file() {
+        let temp_file = NamedTempFile::new().unwrap();
+
+        // Populate the file with real data through the SQLite backend.
+        let sqlite_storage = create_storage(StorageType::Sqlite, temp_file.path()).unwrap();
+        let mut data = StorageData::new();
+        let mut category = Category::new("Work".to_string(), None).unwrap();
+        category.id = 1;
+        data.categories.push(category.clone());
+        let mut task =
+            Task::new("Test task".to_string(), category.id, None, Priority::Medium).unwrap();
+        task.id = 1;
+        data.tasks.push(task);
+        sqlite_storage.save(&data).unwrap();
+
+        // Read the file to verify it has SQLite magic bytes.
+        let file_contents = std::fs::read(temp_file.path()).unwrap();
+        assert!(
+            file_contents.len() >= 16 && &file_contents[..16] == b"SQLite format 3\0",
+            "expected SQLite magic bytes in file"
+        );
+
+        // Pointing JSON storage at a file that already holds SQLite data
+        // must be rejected gracefully with a typed StorageError - never a
+        // panic, and never a silent success that silently overwrites the
+        // SQLite database.
+        let json_storage = create_storage(StorageType::Json, temp_file.path()).unwrap();
+        let new_data = StorageData::new();
+        let result = json_storage.save(&new_data);
+
+        assert!(
+            result.is_err(),
+            "expected a graceful StorageError when saving JSON to a SQLite-populated file, got Ok(..)"
+        );
+
+        // Verify the file still contains SQLite data (not clobbered).
+        let file_after = std::fs::read(temp_file.path()).unwrap();
+        assert_eq!(
+            file_contents, file_after,
+            "SQLite file should not be modified when JSON save is rejected"
+        );
+    }
+
     /// Regression test: deleting a *category* reassigns its tasks
     /// to the magic "Uncategorized" ID (`category_manager::UNCATEGORIZED_ID`,
     /// which is 0). Before this fix, `get_deleted_tasks` treated


### PR DESCRIPTION
`JsonStorage::save` was a bare `std::fs::write` with no check that the path it was writing to actually held JSON. Pointed at a SQLite database, it would overwrite it and destroy the data.

## What changed

`JsonStorage::validate_target_format` runs before any write:

- **Absent or empty file** → proceeds normally. This is the ordinary first-write path and must not regress.
- **SQLite magic header** (`SQLite format 3\0`) → rejected.
- **Exists, non-empty, does not parse as JSON** → rejected.
- On rejection the file is left byte-for-byte untouched.

New typed error variant `StorageError::FormatMismatch(String)`, following the existing variants' `thiserror` style.

## Why, given it was unreachable

Normal configuration cannot reach this: each backend owns a distinct filename inside the `storage.path` directory (`trtodo-data.json` vs `trtodo-data.db`). But that separation is the *only* thing preventing the collision, and it is exactly the kind of arrangement a future cleanup could undo while believing it was removing redundancy — `CLAUDE.md` carries an explicit warning against collapsing it.

This moves the guarantee local to the backend, so it no longer depends on a convention maintained elsewhere. A direct `JsonStorage::new(...)` call with an arbitrary path was also always able to reach it.

This mirrors the SQLite side, which already fails gracefully when opened against a JSON-populated file.

## Tests

Unit tests in `src/storage/json.rs`:

- `test_save_rejects_sqlite_magic_bytes` — asserts the error *and* that the file's bytes are unchanged
- `test_save_to_nonexistent_path_succeeds`
- `test_save_over_existing_valid_json_succeeds` (round-trip)
- `test_save_rejects_invalid_json`

Plus `test_json_rejects_sqlite_populated_file` in `src/storage/mod.rs`, the mirror image of the existing `test_sqlite_rejects_json_populated_file`.

Full suite: 154 tests across 7 binaries, up from the 149 baseline. `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass.

Closes #37