### PR TITLE
fix(category): carry default-category across a rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The keys below are the configurable ones - they are exactly what `config set`, `
 | `deleted-task-lifespan` | `0`                | integer<1..?>       | Number of days before task in Deleted category are deleted. A value of 0, the default, indicates they are never automatically deleted |
 | `storage.type`          | `json`             | `json\|sqlite`      | Type of storage backend to use                                                                                                        |
 | `storage.path`          | `~/.config/trtodo` | string              | Path to storage location                                                                                                              |
-| `default-category`      | `null`             | string              | Category `add` files new tasks into when no `--category` is given and no category context is set. Must name an existing category (by name or ID) - `add` reports an error rather than guessing if it no longer resolves. Renaming a category does not update this setting |
+| `default-category`      | `null`             | string              | Category `add` files new tasks into when no `--category` is given and no category context is set. Must name an existing category (by name or ID) - `add` reports an error rather than guessing if it no longer resolves. `category update` carries this setting along when it renames the category it currently names |
 | `default-priority`      | `medium`           | `high\|medium\|low` | Default priority for new tasks                                                                                                        |
 
 ### Storage backends

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn run() -> Result<(), CliError> {
         },
         Commands::Category { command } => {
             let storage = open_task_storage(&mut config_manager, prompter.as_mut())?;
-            run_category_command(&*storage, command)?;
+            run_category_command(&*storage, &mut config_manager, command)?;
         }
         Commands::Deleted { command } => {
             let storage = open_task_storage(&mut config_manager, prompter.as_mut())?;
@@ -486,7 +486,11 @@ fn purge_expired_deleted_tasks(
     Ok(())
 }
 
-fn run_category_command(storage: &dyn Storage, command: CategoryCommands) -> Result<(), CliError> {
+fn run_category_command(
+    storage: &dyn Storage,
+    config_manager: &mut ConfigManager,
+    command: CategoryCommands,
+) -> Result<(), CliError> {
     let mut manager = CategoryManager::new(storage);
 
     match command {
@@ -518,6 +522,7 @@ fn run_category_command(storage: &dyn Storage, command: CategoryCommands) -> Res
             let category = resolve_category(&manager, &old_name)?;
             manager.update_category(category.id, new_name.clone())?;
             println!("Category '{}' renamed to '{}'", category.name, new_name);
+            carry_default_category_across_rename(config_manager, &category.name, &new_name)?;
         }
         CategoryCommands::List => {
             let current = manager.get_current_category();
@@ -709,6 +714,44 @@ fn resolve_default_priority(config_manager: &ConfigManager) -> Result<Priority, 
         .get("default-priority")
         .unwrap_or_else(|| "medium".to_string());
     Ok(Priority::from_str(&value)?)
+}
+
+/// Keeps `default-category` pointed at the right category across a rename.
+///
+/// `default-category` stores a *name* rather than a resolved ID, and does so
+/// on purpose (see `resolve_add_category`): a stored ID could silently start
+/// pointing at an unrelated category once IDs are recycled, whereas a stored
+/// name only ever fails to resolve - a failure `add` can report. Storing a
+/// name instead of an ID buys that safety at the cost of needing to be kept
+/// in step by hand whenever the name it points at changes, which is exactly
+/// what a rename does. Without this, `category update` on the category
+/// `default-category` names would silently orphan the setting: it would keep
+/// naming the *old* name, which no longer resolves to anything, and `add`
+/// would only find out - as an error - the next time it fell through to step
+/// 3 of its resolution chain.
+///
+/// This lives in `main` rather than `CategoryManager::update_category`
+/// because `CategoryManager` knows nothing about config, and should not
+/// start now just to carry one setting - `main` is the thin dispatch layer
+/// that already holds both.
+///
+/// Comparison is case-insensitive, matching how category names are looked up
+/// everywhere else (`Storage::get_category_by_name`,
+/// `is_reserved_category_name`). Only a `default-category` that actually
+/// named the renamed category is touched; an unset setting, or one naming
+/// some other category, is left alone.
+fn carry_default_category_across_rename(
+    config_manager: &mut ConfigManager,
+    old_name: &str,
+    new_name: &str,
+) -> Result<(), CliError> {
+    if let Some(configured) = config_manager.get("default-category") {
+        if configured.eq_ignore_ascii_case(old_name) {
+            config_manager.set("default-category", new_name)?;
+            println!("Updated config 'default-category' to '{}'", new_name);
+        }
+    }
+    Ok(())
 }
 
 /// Resolves the category a task created by `add` should land in.

--- a/tests/category_commands.rs
+++ b/tests/category_commands.rs
@@ -108,6 +108,87 @@ fn category_lifecycle() {
     assert!(err.contains("Nope"), "{err}");
 }
 
+/// Renaming the category that `default-category` names must carry the
+/// setting along, rather than leaving it pointed at a name that no longer
+/// resolves to anything.
+#[test]
+fn category_update_carries_default_category_along() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["config", "set", "default-category=Work"]);
+
+    let out = trtodo.ok(&["category", "update", "Work", "Werk"]);
+    assert!(
+        out.contains("Updated config 'default-category' to 'Werk'"),
+        "{out}"
+    );
+
+    // The setting now names the renamed category...
+    let out = trtodo.ok(&["config", "list"]);
+    assert!(out.contains("default-category = Werk"), "{out}");
+
+    // ...and a bare `add` resolves it rather than erroring, landing the task
+    // in the renamed category.
+    let out = trtodo.ok(&["add", "Buy milk"]);
+    assert!(out.contains("in category 'Werk'"), "{out}");
+
+    let out = trtodo.ok(&["list"]);
+    assert!(
+        out.contains("Buy milk (priority: medium, category: Werk)"),
+        "{out}"
+    );
+}
+
+/// Renaming some *other* category must not disturb `default-category` -
+/// only a rename of the category it actually names carries it along.
+#[test]
+fn category_update_leaves_unrelated_default_category_alone() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["category", "add", "Home"]);
+    trtodo.ok(&["config", "set", "default-category=Work"]);
+
+    let out = trtodo.ok(&["category", "update", "Home", "Personal"]);
+    assert!(!out.contains("default-category"), "{out}");
+
+    let out = trtodo.ok(&["config", "list"]);
+    assert!(out.contains("default-category = Work"), "{out}");
+}
+
+/// With `default-category` unset, a rename has nothing to carry along and
+/// must not fabricate a value.
+#[test]
+fn category_update_with_no_default_category_set_is_a_no_op_for_config() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+
+    let out = trtodo.ok(&["category", "update", "Work", "Werk"]);
+    assert!(!out.contains("default-category"), "{out}");
+
+    let out = trtodo.ok(&["config", "list"]);
+    assert!(out.contains("*default-category = null"), "{out}");
+}
+
+/// The comparison between the stored `default-category` and the category
+/// being renamed is case-insensitive, matching how category names are
+/// matched everywhere else in this codebase (duplicate detection, `--category`
+/// resolution).
+#[test]
+fn category_update_matches_default_category_case_insensitively() {
+    let trtodo = Trtodo::new();
+    trtodo.ok(&["category", "add", "Work"]);
+    trtodo.ok(&["config", "set", "default-category=work"]);
+
+    let out = trtodo.ok(&["category", "update", "Work", "Werk"]);
+    assert!(
+        out.contains("Updated config 'default-category' to 'Werk'"),
+        "{out}"
+    );
+
+    let out = trtodo.ok(&["config", "list"]);
+    assert!(out.contains("default-category = Werk"), "{out}");
+}
+
 #[test]
 fn category_context_persists_between_runs() {
     let trtodo = Trtodo::new();


### PR DESCRIPTION
Renaming a category left a `default-category` that named it dangling:

```sh
trtodo category add Work
trtodo config set default-category=Work
trtodo category update Work Werk     # rename
trtodo add "Buy milk"                # default-category no longer resolves
```

## What changed

`CategoryCommands::Update` now calls a new `carry_default_category_across_rename` helper after a successful rename. If `default-category` names the category being renamed, the setting is rewritten to the new name through `ConfigManager::set` and the change is reported on one line.

Comparison is case-insensitive (`eq_ignore_ascii_case`), matching how category names are looked up everywhere else (`Storage::get_category_by_name`, `is_reserved_category_name`). It compares against the *stored* old name rather than the user's argument, so casing differences in the command line don't matter. An unset setting, or one naming a different category, is left alone.

A `default-category` holding an ID rather than a name needs no fixup — the ID still resolves after a rename.

## Why the setting still stores a name

Unchanged and deliberate: category IDs are handed back out after a delete, so a stored ID could silently start pointing at an *unrelated* category. A stored name can only ever fail to resolve, and that is a failure `add` can report rather than guess around. The cost of that choice is that the name has to be kept in step by hand when it changes — which is what this PR does.

## Why this lives in `main.rs`

The issue noted this crosses a layering line, since `category_manager` knows nothing about config. Rather than give `CategoryManager` a config dependency for the sake of one setting, the rewrite happens in `main.rs` — the thin dispatch layer that already holds both config and storage, and where the sibling resolution helpers (`resolve_add_category`, `resolve_task_scope`, `require_category_context`) already live for the same reason. `CategoryManager` is untouched.

## README

The config table previously documented the bug as intended behavior ("Renaming a category does not update this setting"). Since `README.md` is the specification, that row now states that `category update` carries the setting along.

## Tests

Four integration tests in `tests/category_commands.rs`, all shelling out to the real binary with `--config` pointed at a `TempDir`:

- `category_update_carries_default_category_along` — the full reproduction above, asserting the bare `add` succeeds and the task lands in the renamed category
- `category_update_leaves_unrelated_default_category_alone`
- `category_update_with_no_default_category_set_is_a_no_op_for_config`
- `category_update_matches_default_category_case_insensitively`

Full suite: 153 tests across 7 binaries, up from the 149 baseline. `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass.

Closes #36