### PR TITLE
docs: bring the backlog and working notes up to date

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,11 @@ builds it on demand; `get_next_category_id` never hands out 0. Consequences:
 
 - `CategoryManager::list_categories` drops any stored row with ID 0 and
   substitutes its own.
+- **Order `0` is reserved for it too.** `list_categories` sorts on
+  `(order, name)`, and the synthesized Uncategorized is pinned at order 0 so it
+  always sorts first. That is why `category order`/`reorder` hand out 1-based
+  positions and reject 0: a real category given order 0 would tie Uncategorized
+  and race it alphabetically for the top slot.
 - SQLite has a `tasks.category_id` foreign key, so a task in Uncategorized
   references a row that does not otherwise exist. `SqliteStorage::save` seeds a
   sentinel row and `load` filters it back out. **Do not "clean up" either half** —
@@ -133,29 +138,40 @@ commits.
 
 Open and deliberately not started:
 
-- **#16 category ordering** — needs an `order` field honored across both
-  backends plus a reorder command. `Category.order` already exists and is
-  persisted, but nothing lets a user set it.
 - **#19 split `config.rs`** — it does three jobs (key schema/validation,
   persistence, backend construction). Collides with anything else touching
   config, so do it on a quiet tree.
 - **#20 / #21 tests and doc comments** — re-scoped from open-ended wishes into
   checklists with an exit condition. #20's real gap is backend parity: most
   behaviour is exercised against JSON only, which is how the SQLite
-  foreign-key bug shipped.
-- **#36 category rename orphans `default-category`** — the setting stores a
-  name (IDs get recycled, which is worse), and nothing keeps it in step.
-- **#37 `JsonStorage::save` has no format check** — unreachable through
-  configuration, guarded only by the distinct-filenames invariant above.
+  foreign-key bug shipped. The ordering work closed part of that gap by
+  covering both backends; the rest of the suite still leans on JSON.
 
 #4 is closed: all four of its bullets landed.
 
+## State as of PRs #39–#41
+
+Three parallel branches, each squash-merged as one conventional commit.
+
+- **#37 → #39.** `JsonStorage::save` now rejects a target that is non-empty and
+  not JSON, so the "never clobber a SQLite file" guarantee is local to the
+  backend instead of resting entirely on the distinct-filenames invariant.
+  That invariant still matters and is still not to be collapsed — the check is
+  a second line, not a replacement.
+- **#36 → #40.** `category update` carries a `default-category` that names the
+  renamed category. The rewrite lives in `main.rs`, so `CategoryManager` still
+  knows nothing about config.
+- **#16 → #41.** `category order` and `category reorder` exist; the
+  `#[allow(dead_code)]` markers on `set_category_order`/`reorder_categories`
+  are gone. Positions are 1-based — see the Uncategorized invariant above for
+  why 0 is not available.
+
 ## Rough edges and session cost
 
-`docs/WORKING-NOTES.md` covers what this file deliberately leaves out: known
-defects not yet filed (renaming a category orphans `default-category`), build
+`docs/WORKING-NOTES.md` covers what this file deliberately leaves out: build
 facts that surprise people (`cargo test --lib` fails — there is no lib target;
-`rusqlite` is bundled, so never delete `target/`), and the practices that keep
+`rusqlite` is bundled, so never delete `target/`), the one way sharing a cargo
+target directory across worktrees will lie to you, and the practices that keep
 an AI-assisted session from spending its budget re-deriving known things.
 
 Read it before parallelizing work across subagents or scoping a branch from an

--- a/docs/WORKING-NOTES.md
+++ b/docs/WORKING-NOTES.md
@@ -13,26 +13,11 @@ how to spend fewer tokens getting the same work done.
 
 ## Rough edges
 
-### Two further gaps
-
-- **Renaming a category orphans a `default-category` that names it** (#36). The
-  setting stores a name on purpose (IDs are handed back out after a delete,
-  so a stored ID can silently start pointing at an unrelated category). The
-  consequence is that `category update Work Werk` leaves
-  `default-category=Work` dangling, and the next bare `add` fails to resolve
-  it. Renaming should probably follow the setting across.
-
-- **`JsonStorage::save` is a bare `fs::write` with no format check** (#37). Not
-  reachable through configuration now that each backend owns a distinct
-  filename, but a direct constructor call could still have JSON clobber a
-  SQLite file. The distinct filenames are what make this unreachable — see
-  the warning in `CLAUDE.md` about not "cleaning up" that arrangement.
-
 ### Build and test facts that surprise people
 
 - **There is no lib target.** `cargo test --lib` fails outright with `no
-  library targets found in package`. The ~99 unit tests live in the binary
-  target alongside the 50 integration tests. Use plain `cargo test`, or
+  library targets found in package`. The unit tests live in the binary
+  target alongside the integration tests. Use plain `cargo test`, or
   `cargo test --bin trtodo` to skip the integration suites.
 
 - **`rusqlite` is vendored with `features = ["bundled"]`**, so a cold build
@@ -45,8 +30,17 @@ how to spend fewer tokens getting the same work done.
   CI runs the strict form. A bare clippy run that looks clean proves
   nothing about whether CI will pass.
 
-- **Current state:** 149 tests across 7 binaries (99 unit + 3 + 3 + 14 + 7
+- **Current state:** 173 tests across 7 binaries (111 unit + 15 + 3 + 14 + 7
   + 6 + 17). If that total drops, something was deleted rather than fixed.
+
+- **A shared `CARGO_TARGET_DIR` across worktrees will lie to you.** Sharing one
+  target directory between parallel worktrees looks like an easy way to avoid
+  paying the bundled-`rusqlite` cold build more than once. It is not: every
+  worktree writes the same `debug/trtodo`, and the integration tests invoke
+  exactly that binary. Two agents building concurrently means one runs its
+  tests against the other's binary, and the failures that produces are
+  spurious and unreproducible. Give each worktree its own target directory and
+  pay the build, or build them one at a time.
 
 ---
 
@@ -79,7 +73,19 @@ individual branch was green.
 If you parallelize, reserve real budget for a combined smoke test that
 exercises the features *against each other*, not just a merge that compiles.
 
-### 3. Check the issue against the code before scoping work from it
+### 3. Check what an agent ran, not what it says it did
+
+A subagent reporting "all tests pass" is a claim about whatever command it
+actually ran. One reported success here having run only `cargo test --bin
+trtodo`, which skips all seven integration suites — the exact place this
+project's regressions surface. Another reported a passing suite whose numbers
+came from a target directory a concurrent build was overwriting.
+
+Neither agent was being careless in a way its own transcript would reveal.
+Re-run the full trio yourself on the branch before opening a pull request; it
+is seconds against a warm build, and it is the only number worth quoting.
+
+### 4. Check the issue against the code before scoping work from it
 
 Issue text goes stale. One issue here asserted that `SCHEMA_VERSION` was
 "a hardcoded 1" and proposed deleting the version table on that basis; the
@@ -88,7 +94,7 @@ the issue as written would have destroyed history.
 
 One `grep` before scoping is cheaper than one wrong branch.
 
-### 4. Decide the commit convention before branching, not after
+### 5. Decide the commit convention before branching, not after
 
 Retrofitting Conventional Commits onto four already-merged branches meant
 cherry-picking, re-resolving conflicts that had already been resolved once,
@@ -97,7 +103,7 @@ identical output. That verification was worth doing — it caught a
 duplicated README row — but the whole exercise was avoidable by deciding
 the format up front.
 
-### 5. Read ranges, not whole files
+### 6. Read ranges, not whole files
 
 Four files here are 700–1100 lines. Reading one end to end to change a
 comment near the bottom costs the whole file every time. `grep -n` for the
@@ -106,14 +112,14 @@ anchor, then read the range around it.
 Conversely: don't re-read a file immediately after editing it to "check"
 the edit. A failed edit reports itself.
 
-### 6. Run the full CI trio once, at the end
+### 7. Run the full CI trio once, at the end
 
 `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test`.
 Running all three after every small edit triples the cost of iterating for
 no added signal. Run `cargo check` while working; run the trio before
 pushing.
 
-### 7. Let `CLAUDE.md` do its job
+### 8. Let `CLAUDE.md` do its job
 
 It is loaded automatically at session start. That is precisely why it must
 stay short and stay true: everything in it is paid for on every single


### PR DESCRIPTION
Follow-up to #39, #40 and #41. Those three were deliberately kept out of the docs, because all three would have edited the same `CLAUDE.md` section and conflicted with each other for no benefit. This is that edit, done once.

## `CLAUDE.md`

- The backlog no longer lists #16, #36 and #37 as "open and deliberately not started". What remains is #19, #20 and #21 — with a note that the ordering work closed part of #20's backend-parity gap by covering both backends, so the next person scoping it does not rediscover that.
- New "State as of PRs #39–#41" section, replacing the stale framing that stopped at #34.
- **Order `0` is now recorded as reserved for `Uncategorized`**, alongside the existing synthesized-never-stored consequences. This is the same invariant, but it just gained a user-facing surface that has to respect it: `list_categories` sorts on `(order, name)` with `Uncategorized` pinned at 0, which is exactly why `category order`/`reorder` are 1-based and reject 0. Someone "tidying" that to 0-based would silently break the always-first guarantee.

## `docs/WORKING-NOTES.md`

- Test baseline 149 → **173** (111 unit + 15 + 3 + 14 + 7 + 6 + 17).
- Drops the "Two further gaps" section — both #36 and #37 are fixed.
- **New: a shared `CARGO_TARGET_DIR` across worktrees will lie to you.** Sharing one target directory between parallel worktrees looks like the obvious way to avoid paying the bundled-`rusqlite` cold build three times. It isn't: every worktree writes the same `debug/trtodo`, and the integration tests invoke exactly that binary, so concurrent builds make one agent test against another's binary. This session hit it and spent real time on a spurious failure.
- **New: check what an agent ran, not what it says it did.** One agent here reported success having run only `cargo test --bin trtodo`, which skips all seven integration suites.

Both new entries are things this session paid for, which is the stated bar for that file.

Docs only — no code changes. `main` is at 173 tests passing with fmt and strict clippy clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Bi3QKg1kYzrxJS89iihFR)_