### PR TITLE
docs: add a roadmap for the work past phase 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,17 @@ Three parallel branches, each squash-merged as one conventional commit.
   are gone. Positions are 1-based — see the Uncategorized invariant above for
   why 0 is not available.
 
+## Roadmap
+
+`docs/ROADMAP.md` is the plan past phase 1: release engineering first, then
+due dates, then a command a scheduler can call, plus the rough edges found
+reviewing the tree against the README. Issue #43 tracks it and carries the
+same list as sub-issues.
+
+Read it before scoping new work. Several items are ordered behind decisions
+nobody has made yet — building them in the wrong order means encoding a guess
+about date formats or display timezones into four places at once.
+
 ## Rough edges and session cost
 
 `docs/WORKING-NOTES.md` covers what this file deliberately leaves out: build

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,113 @@
+# Roadmap
+
+Where this project goes after phase 1, and why in that order.
+
+The README names four phases and has since the first commit. This file is the
+bridge between those sentences and the issues that implement them: what is
+actually left, what has to be decided before it can be built, and what is
+deliberately not being worked on yet.
+
+Issue #43 is the tracking issue and holds the same list as sub-issues. When
+the two disagree, the issues win — this file is a map, not a database.
+
+---
+
+## Where phase 1 landed
+
+Phase 1 as the README describes it — tasks, categories, centralized config,
+JSON storage, "ultimately SQLite" — is done. Both backends exist and migrate
+between each other, categories have a persistent context and an explicit
+order, deletion is soft and reversible, config has defaults, validation, and a
+first-run offer.
+
+What that leaves is a CLI nobody can install and a data model carrying fields
+the CLI never exposes.
+
+---
+
+## Release engineering
+
+First, because none of the rest reaches a user otherwise, and because the
+decisions it forces — supported platforms, MSRV, package identity — get more
+expensive the longer there is code depending on the answer.
+
+| Issue | What |
+| --- | --- |
+| #45 | Package metadata and an MSRV. The manifest is still the `cargo new` default plus dependencies, and the supported Rust version is "whatever stable was when CI last ran". |
+| #46 | CI beyond `ubuntu-latest`. Nothing has ever built or run on macOS or Windows, and the README documents a Windows config path. |
+| #47 | `tempfile` is a normal dependency but only used under `#[cfg(test)]`. |
+| #44 | The release workflow itself: tag-triggered cross-platform binaries, checksums, generated notes, a real install section. |
+| #48 | The documented test count is an invariant nothing enforces, and two documents already disagree about it. |
+
+#44 comes last of these on purpose: building binaries for platforms the suite
+has never run on, from a manifest that does not say what license they are
+under, is publishing guesses.
+
+## Phase 2 — dates and times
+
+Further along than it looks. `Task::due_date` is a real, fully persisted
+field: a `due_date TEXT` column in the SQLite schema, serialized in JSON,
+round-tripped on load, with a setter. The storage half is paid for. The user
+half does not exist — nothing sets a due date, nothing shows one, nothing
+filters on one.
+
+| Issue | What |
+| --- | --- |
+| #49 | Decide the input formats and the display timezone. A decision, not code. |
+| #50 | Expose due dates: set at creation, change, clear, show in `list`, mark overdue. |
+| #51 | Filter and sort by due date, and decide `list`'s sort order explicitly. |
+
+#49 leads because every later piece encodes its answer, and because the one
+timestamp the CLI displays today deliberately punted on the local-time
+question until something forced it. Due dates are that something.
+
+## Phase 3 — reminders
+
+The README's "scheduler / cron / etc." phase. The honest shape for a CLI is
+not a daemon: it is a command that is pleasant to put in a crontab, letting
+the scheduler and the notifier be whatever the user already runs.
+
+| Issue | What |
+| --- | --- |
+| #52 | Machine-readable output (`--format json`). A scheduler needs something to parse, and today every command prints prose whose wording has already changed once. |
+| #53 | The command a scheduler calls: due/overdue tasks, a real exit-code contract, silent when there is nothing to say, never prompting. |
+
+## Phase 4 — sync
+
+Not scoped, and deliberately without issues. It needs a conflict model before
+it needs code; filing implementation issues now would be filing guesses.
+Revisit once phase 3 ships.
+
+---
+
+## Rough edges
+
+Found reviewing the tree against the README rather than against the backlog.
+None blocks a phase. They are on the roadmap because each one is the kind of
+thing that stops being cheap to change once there is a release with users
+behind it.
+
+| Issue | What |
+| --- | --- |
+| #54 | `list` ignores the category context and cannot be scoped to a category, while every other task command honours it. |
+| #55 | `description` is persisted on tasks and categories, threaded through the manager APIs, and can never be set. |
+| #56 | Eighteen blanket `#[allow(dead_code)]` markers, hiding at least four pieces of genuinely unreachable surface. |
+
+## Standing backlog
+
+#19 (split `config.rs`), #20 (test coverage gaps), and #21 (inline docs) predate
+this roadmap and are not duplicated into it. #20's backend-parity bullet and
+#46 overlap deliberately: one is the tests, the other is somewhere to run them.
+
+---
+
+## Deliberately not filed
+
+- **Sync**, above.
+- **Recurring tasks.** Plausible once due dates exist. A repeat rule interacts
+  with soft deletion and completion in ways worth designing against real
+  due-date usage rather than in the abstract.
+- **Task ordering.** Categories have explicit order; `Task.order` exists and no
+  command touches it. Whether that becomes a feature or gets deleted is part
+  of #56, and #51 is the natural moment to answer it, since defining `list`'s
+  sort order forces the question.


### PR DESCRIPTION
Docs only. Adds `docs/ROADMAP.md` and a short pointer to it from `CLAUDE.md`.

## Why

The README has described four phases since the first commit, but nothing connected those sentences to issues. Reviewing the tree against the README turned up three things worth writing down:

- Phase 1 is done, and there is no release — no tags, no GitHub Releases, `version = "0.1.0"` since the first commit, and the only install instruction is `cargo build` against a `rusqlite` that compiles SQLite from C source.
- Phase 2 is half-built and invisible. `Task::due_date` is fully persisted — a real `due_date TEXT` column, RFC 3339 round-trip, JSON serialization, a setter — and has no CLI surface whatsoever. The storage half is already paid for.
- Several smaller gaps are the kind that stop being cheap to change once a release exists: `list` ignores the category context, `description` is persisted everywhere and settable nowhere, and eighteen blanket `#[allow(dead_code)]` markers are hiding which surface is actually reachable.

## What the roadmap records

Ordering reasons, not just an order. The date-format and display-timezone decision comes before anything encodes it — the one timestamp the CLI prints today explicitly deferred the local-vs-UTC question until something forced it, and due dates are that something. The release workflow lands after the platform and package-metadata questions it depends on, because building binaries for platforms the suite has never run on, from a manifest that does not state a license, is publishing guesses.

It also records what is deliberately *not* being worked on — sync, recurring tasks, task ordering — so the next session does not re-derive those as open questions.

## Issues

Filed alongside this and tracked as sub-issues of #43:

- Release engineering: #45, #46, #47, #44, #48
- Phase 2 (dates): #49, #50, #51
- Phase 3 (reminders): #52, #53
- Rough edges: #54, #55, #56

#19, #20, and #21 are left as the standing backlog and are not duplicated into the tree.

## Notes

`CLAUDE.md` gets a pointer rather than the content, since everything in it is paid for on every session.

No Rust changed, so the CI trio was not run locally — the cold bundled-`rusqlite` build costs minutes and proves nothing about a markdown diff. CI will run it.

Refs #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh6uELM1AbFMV9xNm7SwqK


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh6uELM1AbFMV9xNm7SwqK)_