### PR TITLE
refactor: remove the dead_code markers and the code they hid

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -264,7 +264,6 @@ pub struct ConfigManager {
     storage: Box<dyn Storage>,
 }
 
-#[allow(dead_code)]
 impl ConfigManager {
     pub fn new(config_path: Option<&Path>) -> Result<Self, ConfigError> {
         let config_path = if let Some(path) = config_path {
@@ -283,25 +282,10 @@ impl ConfigManager {
         Ok(Self { storage })
     }
 
-    pub fn save(&self) -> Result<(), ConfigError> {
-        let data = crate::models::StorageData {
-            version: 1,
-            tasks: Vec::new(),
-            categories: Vec::new(),
-            config: self.stored_config(),
-            current_category: None,
-            last_sync: chrono::Utc::now(),
-        };
-        self.storage
-            .save(&data)
-            .map_err(|e| ConfigError::Storage(e.to_string()))
-    }
-
     /// Returns the *effective* value for `key`: whatever is stored, or the
     /// documented default if nothing was ever set. This is what callers that
     /// need a usable value (like `main::open_storage`, which picks the
     /// storage backend and path) should call.
-    #[allow(dead_code)]
     pub fn get(&self, key: &str) -> Option<String> {
         let config = self.effective_config();
         match key {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -14,8 +14,13 @@ pub struct Task {
     pub category_id: u64,
     pub completed: bool,
     pub priority: Priority,
+    // Both backends read and write these two, and both are always `None`/`0`
+    // in practice: no command sets a due date, and nothing orders tasks within
+    // a category. Persisting them anyway is deliberate - dropping either would
+    // be a schema change to remove a column that costs nothing today and that
+    // the planned due-date work needs intact.
     pub due_date: Option<DateTime<Utc>>,
-    pub order: u32, // For custom sorting within category
+    pub order: u32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     /// When this task was soft-deleted, or `None` if it is live.
@@ -27,7 +32,6 @@ pub struct Task {
     pub deleted_at: Option<DateTime<Utc>>,
 }
 
-#[allow(dead_code)]
 impl Task {
     pub fn new(
         title: String,
@@ -54,10 +58,11 @@ impl Task {
         })
     }
 
-    pub fn is_uncategorized(&self) -> bool {
-        self.category_id == 0
-    }
-
+    /// Whether this task is soft-deleted. `Storage::live_tasks` and
+    /// `Storage::get_deleted_tasks` are the two callers that matter: they are
+    /// exact opposites of each other, and routing both through this predicate
+    /// is what keeps them from drifting into disagreeing about what "deleted"
+    /// means.
     pub fn is_deleted(&self) -> bool {
         self.deleted_at.is_some()
     }
@@ -126,24 +131,8 @@ impl Task {
         self.category_id = new_category_id;
         self.updated_at = Utc::now();
     }
-
-    pub fn set_due_date(&mut self, due_date: Option<DateTime<Utc>>) {
-        self.due_date = due_date;
-        self.updated_at = Utc::now();
-    }
-
-    pub fn set_priority(&mut self, priority: Priority) {
-        self.priority = priority;
-        self.updated_at = Utc::now();
-    }
-
-    pub fn set_order(&mut self, order: u32) {
-        self.order = order;
-        self.updated_at = Utc::now();
-    }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum TaskError {
     #[error("Task title cannot be empty")]
@@ -163,7 +152,6 @@ pub struct Category {
     pub created_at: DateTime<Utc>,
 }
 
-#[allow(dead_code)]
 impl Category {
     pub fn new(name: String, description: Option<String>) -> Result<Self, CategoryError> {
         if name.trim().is_empty() {
@@ -192,7 +180,6 @@ impl Category {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum CategoryError {
     #[error("Category name cannot be empty")]
@@ -212,7 +199,6 @@ pub enum Priority {
     Low,
 }
 
-#[allow(dead_code)]
 impl Priority {
     pub fn from_str(s: &str) -> Result<Self, PriorityError> {
         match s.to_lowercase().as_str() {
@@ -230,13 +216,8 @@ impl Priority {
             Priority::Low => "low",
         }
     }
-
-    pub fn default() -> Self {
-        Priority::Medium
-    }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum PriorityError {
     #[error("Invalid priority value: {0}")]
@@ -296,7 +277,6 @@ impl StorageData {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Error)]
 pub enum StorageError {
     #[error("IO error: {0}")]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,7 +9,6 @@ pub mod sqlite;
 #[cfg(test)]
 pub mod test_utils;
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StorageType {
     Json,
@@ -58,7 +57,6 @@ impl StorageType {
     }
 }
 
-#[allow(dead_code)]
 pub trait Storage {
     fn save(&self, data: &StorageData) -> Result<(), StorageError>;
     fn load(&self) -> Result<StorageData, StorageError>;
@@ -67,12 +65,6 @@ pub trait Storage {
     fn add_task(&self, task: Task) -> Result<(), StorageError> {
         let mut data = self.load()?;
         data.tasks.push(task);
-        self.save(&data)
-    }
-
-    fn delete_task(&self, task_id: u64) -> Result<(), StorageError> {
-        let mut data = self.load()?;
-        data.tasks.retain(|t| t.id != task_id);
         self.save(&data)
     }
 
@@ -97,25 +89,6 @@ pub trait Storage {
         Ok(data.tasks.into_iter().find(|t| t.id == task_id))
     }
 
-    fn add_category(&self, category: Category) -> Result<(), StorageError> {
-        let mut data = self.load()?;
-        data.categories.push(category);
-        self.save(&data)
-    }
-
-    fn update_category(&self, category: Category) -> Result<(), StorageError> {
-        let mut data = self.load()?;
-        if let Some(existing_category) = data.categories.iter_mut().find(|c| c.id == category.id) {
-            *existing_category = category;
-            self.save(&data)
-        } else {
-            Err(StorageError::Storage(format!(
-                "Category with id {} not found",
-                category.id
-            )))
-        }
-    }
-
     fn get_category(&self, category_id: u64) -> Result<Option<Category>, StorageError> {
         let data = self.load()?;
         Ok(data.categories.into_iter().find(|c| c.id == category_id))
@@ -129,11 +102,7 @@ pub trait Storage {
     /// their own comments.
     fn live_tasks(&self) -> Result<Vec<Task>, StorageError> {
         let data = self.load()?;
-        Ok(data
-            .tasks
-            .into_iter()
-            .filter(|t| t.deleted_at.is_none())
-            .collect())
+        Ok(data.tasks.into_iter().filter(|t| !t.is_deleted()).collect())
     }
 
     fn get_tasks_by_category(&self, category_id: u64) -> Result<Vec<Task>, StorageError> {
@@ -157,23 +126,6 @@ pub trait Storage {
             .live_tasks()?
             .into_iter()
             .filter(|t| t.completed)
-            .collect())
-    }
-
-    fn get_incomplete_tasks(&self) -> Result<Vec<Task>, StorageError> {
-        Ok(self
-            .live_tasks()?
-            .into_iter()
-            .filter(|t| !t.completed)
-            .collect())
-    }
-
-    fn search_tasks(&self, query: &str) -> Result<Vec<Task>, StorageError> {
-        let query = query.to_lowercase();
-        Ok(self
-            .live_tasks()?
-            .into_iter()
-            .filter(|t| t.title.to_lowercase().contains(&query))
             .collect())
     }
 
@@ -230,10 +182,6 @@ pub trait Storage {
             .find(|c| c.name.to_lowercase() == name))
     }
 
-    fn get_category_id_by_name(&self, name: &str) -> Result<Option<u64>, StorageError> {
-        Ok(self.get_category_by_name(name)?.map(|c| c.id))
-    }
-
     fn move_task_to_category(
         &self,
         task_id: u64,
@@ -252,14 +200,6 @@ pub trait Storage {
         }
     }
 
-    fn get_tasks_by_category_name(&self, category_name: &str) -> Result<Vec<Task>, StorageError> {
-        if let Some(category_id) = self.get_category_id_by_name(category_name)? {
-            self.get_tasks_by_category(category_id)
-        } else {
-            Ok(Vec::new())
-        }
-    }
-
     /// Tasks that have been soft-deleted (`Task::soft_delete`), regardless of
     /// which real category they belong to.
     ///
@@ -273,11 +213,7 @@ pub trait Storage {
     /// no longer be confused with each other.
     fn get_deleted_tasks(&self) -> Result<Vec<Task>, StorageError> {
         let data = self.load()?;
-        Ok(data
-            .tasks
-            .into_iter()
-            .filter(|t| t.deleted_at.is_some())
-            .collect())
+        Ok(data.tasks.into_iter().filter(|t| t.is_deleted()).collect())
     }
 
     fn soft_delete_task(&self, task_id: u64) -> Result<(), StorageError> {
@@ -372,30 +308,6 @@ pub trait Storage {
         self.live_tasks()
     }
 
-    fn get_tasks_by_priority_and_category(
-        &self,
-        priority: Priority,
-        category_id: u64,
-    ) -> Result<Vec<Task>, StorageError> {
-        Ok(self
-            .live_tasks()?
-            .into_iter()
-            .filter(|t| t.priority == priority && t.category_id == category_id)
-            .collect())
-    }
-
-    fn get_tasks_by_completion_and_category(
-        &self,
-        completed: bool,
-        category_id: u64,
-    ) -> Result<Vec<Task>, StorageError> {
-        Ok(self
-            .live_tasks()?
-            .into_iter()
-            .filter(|t| t.completed == completed && t.category_id == category_id)
-            .collect())
-    }
-
     fn get_tasks_by_completion_and_priority(
         &self,
         completed: bool,
@@ -405,21 +317,6 @@ pub trait Storage {
             .live_tasks()?
             .into_iter()
             .filter(|t| t.completed == completed && t.priority == priority)
-            .collect())
-    }
-
-    fn get_tasks_by_completion_priority_and_category(
-        &self,
-        completed: bool,
-        priority: Priority,
-        category_id: u64,
-    ) -> Result<Vec<Task>, StorageError> {
-        Ok(self
-            .live_tasks()?
-            .into_iter()
-            .filter(|t| {
-                t.completed == completed && t.priority == priority && t.category_id == category_id
-            })
             .collect())
     }
 }
@@ -481,7 +378,6 @@ fn is_empty(data: &StorageData) -> bool {
 /// survives the switch. The vestigial `config` blob does not: it belongs to
 /// whichever file it is written in (see `StorageData::new`), so the
 /// destination keeps its own.
-#[allow(dead_code)]
 pub fn migrate_storage(
     source: &dyn Storage,
     destination: &dyn Storage,
@@ -514,7 +410,6 @@ pub fn migrate_storage(
     Ok(MigrationOutcome::Migrated { tasks, categories })
 }
 
-#[allow(dead_code)]
 pub fn create_storage(
     storage_type: StorageType,
     path: &Path,
@@ -926,7 +821,12 @@ mod tests {
         category.id = storage.get_next_category_id().unwrap();
         let category_id = category.id;
         assert_ne!(category_id, 0);
-        storage.add_category(category).unwrap();
+        // Seeded the way `CategoryManager` does it - load, push, save - rather
+        // than through a storage-level `add_category` helper, so this test
+        // exercises the same write path production uses.
+        let mut data = storage.load().unwrap();
+        data.categories.push(category);
+        storage.save(&data).unwrap();
 
         let mut task = Task::new(
             "Finish report".to_string(),
@@ -953,7 +853,14 @@ mod tests {
             .get_tasks_by_category(category_id)
             .unwrap()
             .is_empty());
-        assert!(storage.search_tasks("report").unwrap().is_empty());
+        // `get_tasks_by_title` is what task resolution matches names against,
+        // and `get_all_tasks` is what `list` and its `--search` filter read:
+        // between them, a soft-deleted task is unreachable by name and absent
+        // from every listing.
+        assert!(storage
+            .get_tasks_by_title("Finish report")
+            .unwrap()
+            .is_empty());
         assert!(storage.get_all_tasks().unwrap().is_empty());
 
         // get_task is the one exception: it must still be reachable by ID so

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -15,20 +15,17 @@ use std::sync::{Arc, Mutex};
 ///
 /// Bump this *and* teach `initialize_schema` how to get a database from the
 /// previous version to the new one whenever the on-disk shape changes.
-#[allow(dead_code)]
 const SCHEMA_VERSION: i32 = 2;
 
 /// Created and read before anything else, so `initialize_schema` can find out
 /// what it is dealing with *before* it starts mutating tables. Deliberately
 /// separate from `INIT_SCHEMA` below for that ordering alone.
-#[allow(dead_code)]
 const INIT_VERSION_TABLE: &str = r#"
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL
 );
 "#;
 
-#[allow(dead_code)]
 const INIT_SCHEMA: &str = r#"
 -- Create categories table
 CREATE TABLE IF NOT EXISTS categories (
@@ -67,7 +64,6 @@ pub struct SqliteStorage {
     pub conn: Arc<Mutex<Connection>>,
 }
 
-#[allow(dead_code)]
 impl SqliteStorage {
     pub fn new(path: &Path) -> Result<Self, StorageError> {
         let conn = Connection::open(path)


### PR DESCRIPTION
Closes #56. Net −133 lines, no behaviour change.

## What was wrong

Eighteen `#[allow(dead_code)]` attributes, nearly all on whole `impl` blocks and traits rather than individual items — the entire `Storage` trait, all of `impl ConfigManager`, all of `impl SqliteStorage`, all of `impl Task`. Those blocks are overwhelmingly live code, so the markers documented nothing. They switched off the compiler's ability to answer "is this reachable" across several hundred lines at a time, and the genuinely unreachable items inside were never named.

They look deliberate and mostly are not: `SCHEMA_VERSION` carried one while being read by `initialize_schema` on every open. The likely origin is the period before `main.rs` was wired into storage and config at all, when those blocks really were unreferenced; nothing removed them as the code grew callers. #41 removed exactly two, for `set_category_order`/`reorder_categories` — this is the same move applied to the rest.

## What was hiding

Fourteen items nothing calls, all deleted:

| Where | Items |
| --- | --- |
| `Storage` | `delete_task`, `add_category`, `update_category`, `get_incomplete_tasks`, `search_tasks`, `get_category_id_by_name`, `get_tasks_by_category_name`, and three category-crossed filter combinators |
| `Task` | `is_uncategorized`, `set_due_date`, `set_priority`, `set_order` |
| elsewhere | `Priority::default`, `ConfigManager::save` |

Two are worth calling out because they were hazards rather than merely unused:

- **`Storage::delete_task`** was a *hard* delete (`data.tasks.retain(...)`) sitting directly next to `soft_delete_task`. Soft deletion is the whole model; a same-shaped hard delete one method away is a trap waiting for an autocomplete.
- **`ConfigManager::save`** built a fresh `StorageData` rather than loading the existing one, so calling it would have discarded whatever the config store already held. `set` and `unset` load-mutate-save correctly and are what actually runs.

Also gone: three combinators (`get_tasks_by_priority_and_category`, `get_tasks_by_completion_and_category`, `get_tasks_by_completion_priority_and_category`). #51 already argues that the combinator-per-filter-pair approach should stop rather than grow, since every implementation is a linear scan over `live_tasks()` anyway — so removing them narrows what #54's `list --category` has to reason about rather than taking anything away from it.

`search_tasks` being dead is the code-side twin of the `list`/`search` documentation drift noted in #54: storage has a search method, and `TaskManager::list_tasks` does its own `retain` instead.

## What was kept

`Task::is_deleted` was the one item used only by tests. Rather than keep it alive with a narrower marker, `live_tasks` and `get_deleted_tasks` now call it — they are exact opposites of each other, and routing both through one predicate is what stops them from drifting apart on what "deleted" means.

The `due_date` and `order` fields stay. Both are persisted by both backends; dropping either is a schema change to remove a column that costs nothing today, and the planned due-date work needs `due_date` intact. A comment now says so, so the next reader does not mistake them for the setters that just went.

## Tests

Two unit-test assertions reached for methods that are now gone, both in the soft-delete test. It now seeds its category the way `CategoryManager` does — load, push, save — and asserts unreachability by name through `get_tasks_by_title`, which is what task resolution actually matches against. That is a more production-relevant assertion than the one it replaces.

**173 tests across 7 binaries (111 + 15 + 3 + 14 + 7 + 6 + 17), all passing** — identical to the count in `docs/WORKING-NOTES.md`, so nothing was deleted rather than fixed. Full CI trio run locally on this branch: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` (and the stricter `--all-targets` form), `cargo test`.

## Note

Independent of #57, which is docs-only; both branch from `main` and touch no common files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh6uELM1AbFMV9xNm7SwqK


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh6uELM1AbFMV9xNm7SwqK)_