### PR TITLE
docs: record the dead-code cleanup in the roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,18 @@ Three parallel branches, each squash-merged as one conventional commit.
   are gone. Positions are 1-based — see the Uncategorized invariant above for
   why 0 is not available.
 
+## State as of PR #58
+
+`src/` contains no `#[allow(dead_code)]`, and that is the state to preserve.
+Eighteen of them had accumulated, nearly all on whole `impl` blocks and traits
+rather than single items, which switched off reachability analysis across
+hundreds of lines at a time; fourteen genuinely unreachable items were hiding
+behind them, including a hard `Storage::delete_task` next to `soft_delete_task`
+and a `ConfigManager::save` that would have discarded the stored config.
+
+If something is unused, delete it. If it must stay, mark the *item*, not its
+block, and say why in a comment.
+
 ## Roadmap
 
 `docs/ROADMAP.md` is the plan past phase 1: release engineering first, then

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -91,7 +91,11 @@ behind it.
 | --- | --- |
 | #54 | `list` ignores the category context and cannot be scoped to a category, while every other task command honours it. |
 | #55 | `description` is persisted on tasks and categories, threaded through the manager APIs, and can never be set. |
-| #56 | Eighteen blanket `#[allow(dead_code)]` markers, hiding at least four pieces of genuinely unreachable surface. |
+| ~~#56~~ | **Landed.** Eighteen blanket `#[allow(dead_code)]` markers removed, and the fourteen unreachable items behind them deleted. `src/` now has none; keep it that way — a blanket marker on an `impl` block is how the previous fourteen went unnoticed. |
+
+#56 shifted #54 slightly: the two unused storage combinators it cited as
+evidence are gone, so `list --category` starts from a smaller surface rather
+than an existing-but-unused one.
 
 ## Standing backlog
 
@@ -108,6 +112,7 @@ this roadmap and are not duplicated into it. #20's backend-parity bullet and
   with soft deletion and completion in ways worth designing against real
   due-date usage rather than in the abstract.
 - **Task ordering.** Categories have explicit order; `Task.order` exists and no
-  command touches it. Whether that becomes a feature or gets deleted is part
-  of #56, and #51 is the natural moment to answer it, since defining `list`'s
-  sort order forces the question.
+  command touches it. #56 kept the field deliberately — dropping it is a schema
+  change to remove a column that costs nothing — and deleted its unused setter.
+  Whether it becomes a feature is still open, and #51 is the natural moment to
+  answer it, since defining `list`'s sort order forces the question.


### PR DESCRIPTION
Docs only, follow-up to #57 and #58. Both merged, and the roadmap that landed in #57 described #56 as open work — it isn't any more.

## Changes

- `docs/ROADMAP.md`: marks #56 landed, and records the knock-on for #54 — the two unused storage combinators it cited as evidence for `list --category` are gone, so that work starts from a smaller surface rather than an existing-but-unused one.
- The task-ordering note under "deliberately not filed" was wrong as written: #56 kept `Task.order` (dropping it is a schema change to remove a column that costs nothing) and deleted only its unused setter. Corrected, with #51 still named as the moment that forces the question.
- `CLAUDE.md`: a state section recording that `src/` now contains no `#[allow(dead_code)]`, and that a blanket marker on an `impl` block is how the previous fourteen unreachable items went unnoticed. That fact is only useful as an invariant if the next cold session knows it is one.

## Note

No Rust changed, so the CI trio was not run locally — a markdown diff proves nothing against a cold bundled-`rusqlite` build. CI will run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hh6uELM1AbFMV9xNm7SwqK


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh6uELM1AbFMV9xNm7SwqK)_