### PR TITLE
refactor!: rename the binary to trt and finish the release-engineering block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependency updates.
+#
+# Enabled rather than declined: the pinned action versions and crate versions
+# were drifting silently, and the alternative to automation here is a human
+# remembering to re-check them, which is the same failure mode the test-count
+# tripwire was written to avoid.
+#
+# Monthly, not weekly. This is a small CLI with a bundled SQLite build; a
+# weekly cadence on a tree this size produces more pull requests than signal,
+# and a batch that is ignored is worse than no batch.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    # One pull request for all non-major bumps. Majors stay separate because
+    # they are the ones that need a human to read a changelog.
+    groups:
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,18 +48,20 @@ jobs:
         fi
         echo "PR title OK: $PR_TITLE"
 
-  test:
-    name: Test
+  # fmt and clippy are platform-independent, so they run once rather than
+  # once per matrix leg - three identical results buy nothing but minutes.
+  lint:
+    name: Format and lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt, clippy
         toolchain: stable
-    
+
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
@@ -73,8 +75,42 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
 
+    # Stricter than a bare `cargo clippy`: a clean bare run proves nothing
+    # about whether this passes.
     - name: Clippy
       run: cargo clippy -- -D warnings
+
+  # The README promises a Windows config path and `dirs` is what resolves it,
+  # the integration harness builds real temp directories, and StdinPrompter's
+  # "is stdin a terminal" check is not the same call on every platform. None
+  # of that is platform-neutral by accident, so all three are exercised.
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Finish the other platforms rather than cancelling them: when a failure
+      # is platform-specific, knowing which platforms are unaffected is most of
+      # the diagnosis.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: rust-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        shared-key: rust-cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
+        save-if: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
+        workspaces: "**/Cargo.toml"
+        cache-targets: true
+        cache-on-failure: true
 
     - name: Run tests
       run: cargo test --verbose
@@ -91,7 +127,14 @@ jobs:
     # headers to stderr and each harness writes its "test result" line to
     # stdout, so merging the two streams to pair a name with a count relies
     # on interleaving that buffering does not guarantee.
+    #
+    # One leg only: the same tests are compiled everywhere, so the count is
+    # the same everywhere, and reporting it three times would only invite
+    # reading a difference into it. Linux is also the leg where this parses
+    # cleanly - the harness emits CRLF on Windows, which a `': test$'` match
+    # would silently miss.
     - name: Report test counts
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         set -uo pipefail
@@ -112,4 +155,4 @@ jobs:
           echo "| --- | --- |"
           printf '%s' "$rows"
           echo "| **Total** | **$total** |"
-        } | tee -a "$GITHUB_STEP_SUMMARY" 
+        } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,38 @@ jobs:
     - name: Clippy
       run: cargo clippy -- -D warnings
 
+  # The declared floor in Cargo.toml, exercised. Without this the rust-version
+  # field is a claim rather than a fact, and a dependency bump can raise the
+  # real floor with nothing to notice - which is the state this replaced.
+  # Pinned to an exact version on purpose: "the oldest supported" is not a
+  # thing rustup can resolve, so it has to be spelled out in both places and
+  # changed deliberately in both.
+  msrv:
+    name: Minimum supported Rust version
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: "1.78"
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: rust-cargo-msrv-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        shared-key: rust-cargo-msrv-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
+        save-if: ${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
+        workspaces: "**/Cargo.toml"
+        cache-targets: true
+        cache-on-failure: true
+
+    # The whole suite, not just a build. A floor that compiles but fails its
+    # tests is not a supported version.
+    - name: Run tests
+      run: cargo test
+
   # The README promises a Windows config path and `dirs` is what resolves it,
   # the integration harness builds real temp directories, and StdinPrompter's
   # "is stdin a terminal" check is not the same call on every platform. None

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,8 +153,13 @@ jobs:
         cache-targets: true
         cache-on-failure: true
 
+    # --no-fail-fast because this is the matrix job. cargo stops at the first
+    # failing test binary, so a platform that breaks several of them reveals
+    # one per CI round trip, and each round trip is a push and a full rebuild
+    # on three runners. Surfacing every failure in one run is the difference
+    # between one fix and a queue of them.
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --no-fail-fast
 
     # A raw test count is this project's cheapest tripwire for its known
     # failure mode: a test deleted rather than a bug fixed. Reported, not

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,4 +77,39 @@ jobs:
       run: cargo clippy -- -D warnings
 
     - name: Run tests
-      run: cargo test --verbose 
+      run: cargo test --verbose
+
+    # A raw test count is this project's cheapest tripwire for its known
+    # failure mode: a test deleted rather than a bug fixed. Reported, not
+    # enforced - a hard failure on a decreasing count would also fire on
+    # legitimate consolidation, which just teaches people to override it.
+    # The direction of the number is the signal; this is not a coverage
+    # target, which the working notes reject explicitly.
+    #
+    # Counted by asking each test harness for its own list rather than by
+    # parsing `cargo test` output: cargo writes the "Running <binary>"
+    # headers to stderr and each harness writes its "test result" line to
+    # stdout, so merging the two streams to pair a name with a count relies
+    # on interleaving that buffering does not guarantee.
+    - name: Report test counts
+      shell: bash
+      run: |
+        set -uo pipefail
+        total=0
+        rows=""
+        while read -r name exe; do
+          n=$("$exe" --list 2>/dev/null | grep -c ': test$' || true)
+          rows+="| \`$name\` | $n |"$'\n'
+          total=$((total + n))
+        done < <(cargo test --no-run --message-format=json 2>/dev/null \
+          | jq -r 'select(.executable != null and .profile.test == true)
+                   | "\(.target.name) \(.executable)"' \
+          | sort)
+        {
+          echo "### Test counts"
+          echo
+          echo "| Test binary | Tests |"
+          echo "| --- | --- |"
+          printf '%s' "$rows"
+          echo "| **Total** | **$total** |"
+        } | tee -a "$GITHUB_STEP_SUMMARY" 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,15 @@ jobs:
     - name: Clippy
       run: cargo clippy -- -D warnings
 
+    # crates.io is a possible destination, so the manifest is kept publishable
+    # and this is what keeps it that way. Packaging catches the failures that
+    # inspection does not: a missing required field, an invalid category slug,
+    # a file the package needs but .gitignore excludes, or a source tree that
+    # only builds because of something untracked sitting in the working copy.
+    # None of those are visible until something actually packages the crate.
+    - name: Check the crate still packages
+      run: cargo publish --dry-run
+
   # The declared floor in Cargo.toml, exercised. Without this the rust-version
   # field is a claim rather than a fact, and a dependency bump can raise the
   # real floor with nothing to notice - which is the state this replaced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # trusty_rusty_todo_list
 
-A CLI todo list in Rust. Binary name is `trtodo`. Tasks belong to categories;
-configuration and data live under `~/.config/trtodo` by default.
+A CLI todo list in Rust. Binary name is `trt`. Tasks belong to categories;
+configuration and data live under `~/.config/trt` by default.
 
 `README.md` is the specification, not just documentation. Where behavior and
 README disagree, that is a bug in one of them — decide which, and fix that one.
@@ -79,7 +79,7 @@ them; `get_deleted_tasks()` returns them. `list`/`search` must go through
 `live_tasks()`.
 
 **Each storage backend owns its own file** inside the `storage.path` *directory*
-(`trtodo-data.json`, `trtodo-data.db`). They must never point at the same path.
+(`trt-data.json`, `trt-data.db`). They must never point at the same path.
 Changing `storage.type` migrates data via `migrate_storage`, which only ever
 reads the source and refuses to overwrite a non-empty destination.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "1.0.49"
 chrono = { version = "0.4.31", features = ["serde"] }
-tempfile = "3.8.1"
 rusqlite = { version = "0.30.0", features = ["bundled", "chrono"] }
 dirs = "5.0.1"
 shellexpand = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,25 @@ categories = ["command-line-utilities"]
 # into another claim nobody checks.
 rust-version = "1.78"
 
-# Releases are prebuilt binaries, not a crates.io package. Set explicitly so an
-# accidental `cargo publish` cannot happen; flip it if that ever changes, and
-# note the package name and the binary name (trtodo) deliberately differ.
-publish = false
+# Deliberately left publishable rather than set to `publish = false`.
+#
+# crates.io is a possible destination, so the manifest is kept in a state where
+# `cargo publish` would succeed - description, license, repository, keywords,
+# and categories are all present and valid, and `cargo publish --dry-run` is
+# what verifies that rather than inspection. The cost of the other choice is
+# not the one line it takes to flip: `publish = false` also blocks the dry run,
+# so the manifest would rot unpublishable without anything reporting it.
+#
+# Both `trusty_rusty_todo_list` and `trtodo` were unregistered when this was
+# written. Neither is reserved by saying so here - crates.io has no mechanism
+# for that short of publishing - so if the name matters, publishing an early
+# version is the only thing that holds it.
+#
+# Note the package name and the binary name differ: installing this would be
+# `cargo install trusty_rusty_todo_list` to get a `trtodo` on your PATH. That
+# is allowed, and it is worth deciding on purpose before a first publish
+# rather than after, because the package name is the half that cannot be
+# changed afterwards.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,21 +30,28 @@ rust-version = "1.78"
 # not the one line it takes to flip: `publish = false` also blocks the dry run,
 # so the manifest would rot unpublishable without anything reporting it.
 #
-# Both `trusty_rusty_todo_list` and `trtodo` were unregistered when this was
-# written. Neither is reserved by saying so here - crates.io has no mechanism
-# for that short of publishing - so if the name matters, publishing an early
-# version is the only thing that holds it.
+# `trusty_rusty_todo_list` was unregistered when this was written, and saying
+# so reserves nothing - crates.io has no mechanism for holding a name short of
+# publishing to it.
 #
-# Note the package name and the binary name differ: installing this would be
-# `cargo install trusty_rusty_todo_list` to get a `trtodo` on your PATH. That
-# is allowed, and it is worth deciding on purpose before a first publish
-# rather than after, because the package name is the half that cannot be
-# changed afterwards.
+# The package name and the binary name differ on purpose, and the difference is
+# not free: installing this is `cargo install trusty_rusty_todo_list` to get a
+# `trt` on your PATH. `trt` is not available as a package name - it belongs to
+# an unrelated tokio runtime crate - so the two cannot be made to match by
+# renaming the package to the binary. That crate is a library and ships no
+# executable, so nothing it installs can collide with this one; the collision
+# is only over the crates.io namespace.
+#
+# The binary name is the constraint that actually bites, because it is what
+# lands on a stranger's PATH. `tr` was considered and rejected: it is
+# POSIX-specified and ships in coreutils, so shadowing it would break shell
+# scripts anywhere this sorted earlier on PATH, in ways that surface far from
+# the cause.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
-name = "trtodo"
+name = "trt"
 path = "src/main.rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,29 @@
 name = "trusty_rusty_todo_list"
 version = "0.1.0"
 edition = "2021"
+description = "A CLI todo list with categories, priorities, and JSON or SQLite storage"
+# Matches the GPL-3.0 text in LICENSE, which the manifest previously did not
+# reference at all. "-only" rather than "-or-later": the file carries the bare
+# licence text without the "or (at your option) any later version" statement,
+# and that permission has to be granted explicitly rather than assumed.
+license = "GPL-3.0-only"
+repository = "https://github.com/Bombing-Around/trusty_rusty_todo_list"
+readme = "README.md"
+keywords = ["todo", "cli", "tasks", "productivity"]
+categories = ["command-line-utilities"]
+
+# The floor the suite is actually verified against, not the highest version any
+# dependency happens to declare. clap 4.4 asks for 1.70, but the committed
+# Cargo.lock is lockfile v4, which no Cargo before 1.78 can parse - so 1.70 was
+# never reachable no matter what the dependency graph said. The full suite is
+# run against this version in CI so the number stays true instead of drifting
+# into another claim nobody checks.
+rust-version = "1.78"
+
+# Releases are prebuilt binaries, not a crates.io package. Set explicitly so an
+# accidental `cargo publish` cannot happen; flip it if that ever changes, and
+# note the package name and the binary name (trtodo) deliberately differ.
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -18,48 +18,48 @@ Finally, I would love to implement some kind of syncing interface to keep your t
 
 ## Interface 
 
-The binary named `trtodo` will accept various arguments
+The binary named `trt` will accept various arguments
 
 | Command                                                                                               | Description                                                                                                                               |
 | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `trtodo add <title> [--category <category_name or category_id> (or -c)] [--priority <high|medium|low>]` | Add a new task with the given title and optional priority. Omitting `--category` uses the current category context, else `default-category`, else Uncategorized |
-| `trtodo delete <title or id> [--category <category_name or category_id> (or -c)]`                     | Delete the task with the given title                                                                                                      |
-| `trtodo update <title or id> --to <new_title> [--category <category_name or category_id> (or -c)]`    | Update the task with the given title                                                                                                      |
-| `trtodo check (x, mark) <title or id> --category <category_name or category_id> (or -c)`              | Check off the task with the given title                                                                                                   |
-| `trtodo uncheck (o, unmark) <title or id> --category <category_name or category_id> (or -c)`          | Uncheck the task with the given title                                                                                                     |
-| `trtodo check all`                                                                                    | Check off all tasks in current category                                                                                                   |
-| `trtodo uncheck all`                                                                                  | Uncheck all tasks in current category                                                                                                     |
-| `trtodo move <task_name or id> --to <category_name or ID>`                                            | Move task to another category (when in category context)                                                                                  |
-| `trtodo move --from <category_name or ID> --to <category_name or ID> --task <task_name or task_id>`   | Move task from one category to another - optionally omitting the `--to` argument will place the task at the parent level (uncategorized)  |
-| `trtodo list [--search <term>] [--completed] [--priority <high|medium|low>]`                          | List all tasks with their IDs, optionally filtered                                                                                        |
-| `trtodo category use <category_name or category_id>`                                                  | Use category for subsequent task interaction                                                                                              |
-| `trtodo category clear`                                                                               | Clear the current category context                                                                                                        |
-| `trtodo category show`                                                                                | Show current category context                                                                                                             |
-| `trtodo category add <name>`                                                                          | Add a new category with the given name                                                                                                    |
-| `trtodo category delete <name> (--new-category <category_name or category_id>)`                       | Delete a category and optionally move its tasks                                                                                           |
-| `trtodo category update <old_name> <new_name>`                                                        | Update an existing category with the given name                                                                                           |
-| `trtodo category list`                                                                                | List all categories with their IDs                                                                                                        |
-| `trtodo category order <category_name or category_id> <position>`                                     | Move a category to the given 1-based position in `category list`                                                                          |
-| `trtodo category reorder <category_name or category_id>...`                                           | Set the order of several categories at once, in the order given                                                                           |
-| `trtodo config set <key=value>`                                                                       | Set configuration key to value                                                                                                            |
-| `trtodo config default <key>`                                                                         | Unsets the value for key to force use of the default value                                                                                |
-| `trtodo config list`                                                                                  | List all configuration keys and their values, including defaults which will be indicated with an asterisk                                 |
-| `trtodo deleted list`                                                                                 | List all soft-deleted tasks with their IDs, titles, original categories, and deletion dates - i.e. exactly what a `flush` would destroy   |
-| `trtodo deleted restore <title or id>`                                                                | Restore a soft-deleted task to its original category. Matches soft-deleted tasks only, prompting if the title is ambiguous                |
-| `trtodo deleted flush [--yes (or -y, --force)]`                                                       | Permanently remove all soft-deleted tasks, listing them and asking for confirmation first. `--yes` skips the prompt                       |
-| `trtodo --help`                                                                                       | List these commands                                                                                                                       |
-| `trtodo --help <command>`                                                                             | Describe command and its arguments                                                                                                        |
-| `trtodo --config <path>`                                                                              | Uses the configuration file at the given path instead of the default. May also be set via the `TRTODO_CONFIG` environment variable; the flag wins  |
-| `trtodo --yes` (or `-y`)                                                                              | Assume "yes" for confirmation prompts and never read from stdin                                                                           |
-| `trtodo --no-input`                                                                                   | Never prompt: decline confirmations and never read from stdin                                                                             |
+| `trt add <title> [--category <category_name or category_id> (or -c)] [--priority <high|medium|low>]` | Add a new task with the given title and optional priority. Omitting `--category` uses the current category context, else `default-category`, else Uncategorized |
+| `trt delete <title or id> [--category <category_name or category_id> (or -c)]`                     | Delete the task with the given title                                                                                                      |
+| `trt update <title or id> --to <new_title> [--category <category_name or category_id> (or -c)]`    | Update the task with the given title                                                                                                      |
+| `trt check (x, mark) <title or id> --category <category_name or category_id> (or -c)`              | Check off the task with the given title                                                                                                   |
+| `trt uncheck (o, unmark) <title or id> --category <category_name or category_id> (or -c)`          | Uncheck the task with the given title                                                                                                     |
+| `trt check all`                                                                                    | Check off all tasks in current category                                                                                                   |
+| `trt uncheck all`                                                                                  | Uncheck all tasks in current category                                                                                                     |
+| `trt move <task_name or id> --to <category_name or ID>`                                            | Move task to another category (when in category context)                                                                                  |
+| `trt move --from <category_name or ID> --to <category_name or ID> --task <task_name or task_id>`   | Move task from one category to another - optionally omitting the `--to` argument will place the task at the parent level (uncategorized)  |
+| `trt list [--search <term>] [--completed] [--priority <high|medium|low>]`                          | List all tasks with their IDs, optionally filtered                                                                                        |
+| `trt category use <category_name or category_id>`                                                  | Use category for subsequent task interaction                                                                                              |
+| `trt category clear`                                                                               | Clear the current category context                                                                                                        |
+| `trt category show`                                                                                | Show current category context                                                                                                             |
+| `trt category add <name>`                                                                          | Add a new category with the given name                                                                                                    |
+| `trt category delete <name> (--new-category <category_name or category_id>)`                       | Delete a category and optionally move its tasks                                                                                           |
+| `trt category update <old_name> <new_name>`                                                        | Update an existing category with the given name                                                                                           |
+| `trt category list`                                                                                | List all categories with their IDs                                                                                                        |
+| `trt category order <category_name or category_id> <position>`                                     | Move a category to the given 1-based position in `category list`                                                                          |
+| `trt category reorder <category_name or category_id>...`                                           | Set the order of several categories at once, in the order given                                                                           |
+| `trt config set <key=value>`                                                                       | Set configuration key to value                                                                                                            |
+| `trt config default <key>`                                                                         | Unsets the value for key to force use of the default value                                                                                |
+| `trt config list`                                                                                  | List all configuration keys and their values, including defaults which will be indicated with an asterisk                                 |
+| `trt deleted list`                                                                                 | List all soft-deleted tasks with their IDs, titles, original categories, and deletion dates - i.e. exactly what a `flush` would destroy   |
+| `trt deleted restore <title or id>`                                                                | Restore a soft-deleted task to its original category. Matches soft-deleted tasks only, prompting if the title is ambiguous                |
+| `trt deleted flush [--yes (or -y, --force)]`                                                       | Permanently remove all soft-deleted tasks, listing them and asking for confirmation first. `--yes` skips the prompt                       |
+| `trt --help`                                                                                       | List these commands                                                                                                                       |
+| `trt --help <command>`                                                                             | Describe command and its arguments                                                                                                        |
+| `trt --config <path>`                                                                              | Uses the configuration file at the given path instead of the default. May also be set via the `TRT_CONFIG` environment variable; the flag wins  |
+| `trt --yes` (or `-y`)                                                                              | Assume "yes" for confirmation prompts and never read from stdin                                                                           |
+| `trt --no-input`                                                                                   | Never prompt: decline confirmations and never read from stdin                                                                             |
 
 ## Additional Behaviors
 
-The first time `trtodo` is run it should offer to create the default categories of "Home" and "Work" and create a configuration file under `.config\trtodo\` or `C:\\Users\\<username>\\AppData\\Roaming\trtodo`.
+The first time `trt` is run it should offer to create the default categories of "Home" and "Work" and create a configuration file under `.config\trt\` or `C:\\Users\\<username>\\AppData\\Roaming\trt`.
 
 That offer defaults to yes (a bare Enter accepts it) and is made at most once:
 
-- It is made by the first command that touches task storage, not by `trtodo config ...`. Config commands never open task storage, and creating categories from a read-only `config list` - or from the very `config set storage.path=...` that decides where task data belongs - would put data somewhere the user did not ask for.
+- It is made by the first command that touches task storage, not by `trt config ...`. Config commands never open task storage, and creating categories from a read-only `config list` - or from the very `config set storage.path=...` that decides where task data belongs - would put data somewhere the user did not ask for.
 - The answer is recorded in the configuration file, so no later run asks again. Accepting, declining, and already having categories (an existing install, upgraded or otherwise) all count as answered; deleting every category afterwards is a legitimate empty state and does not bring the offer back.
 - With no terminal attached (a pipe, a cron job, CI) there is nobody to ask, so the offer is silently skipped: nothing is created, nothing is recorded, and nothing blocks waiting for input. Pass `--yes` or `--no-input` to give a definite answer from a script.
 
@@ -81,7 +81,7 @@ Category context (set via `category use`) persists between runs of the applicati
 
 ## Configuration Values
 
-Configuration values are stored in `trtodo-config.json`. By default it's written to a config folder unless it's first read in your home directory. 
+Configuration values are stored in `trt-config.json`. By default it's written to a config folder unless it's first read in your home directory. 
 
 The keys below are the configurable ones - they are exactly what `config set`, `config default`, and `config list` operate on. The file may also contain internal bookkeeping that is not a setting (currently `default_categories_offered`, which records that the first-run offer above has been answered); those are not listed by `config list` and cannot be set with `config set`.
 
@@ -89,7 +89,7 @@ The keys below are the configurable ones - they are exactly what `config set`, `
 | ----------------------- | ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `deleted-task-lifespan` | `0`                | integer<1..?>       | Number of days before task in Deleted category are deleted. A value of 0, the default, indicates they are never automatically deleted |
 | `storage.type`          | `json`             | `json\|sqlite`      | Type of storage backend to use                                                                                                        |
-| `storage.path`          | `~/.config/trtodo` | string              | Path to storage location                                                                                                              |
+| `storage.path`          | `~/.config/trt` | string              | Path to storage location                                                                                                              |
 | `default-category`      | `null`             | string              | Category `add` files new tasks into when no `--category` is given and no category context is set. Must name an existing category (by name or ID) - `add` reports an error rather than guessing if it no longer resolves. `category update` carries this setting along when it renames the category it currently names |
 | `default-priority`      | `medium`           | `high\|medium\|low` | Default priority for new tasks                                                                                                        |
 
@@ -99,8 +99,8 @@ The keys below are the configurable ones - they are exactly what `config set`, `
 
 | `storage.type` | Data file          |
 | -------------- | ------------------ |
-| `json`         | `trtodo-data.json` |
-| `sqlite`       | `trtodo-data.db`   |
+| `json`         | `trt-data.json` |
+| `sqlite`       | `trt-data.db`   |
 
 Because of that, changing `storage.type` moves your tasks and categories to the new backend's file:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,15 +33,29 @@ expensive the longer there is code depending on the answer.
 
 | Issue | What |
 | --- | --- |
-| #45 | Package metadata and an MSRV. The manifest is still the `cargo new` default plus dependencies, and the supported Rust version is "whatever stable was when CI last ran". |
-| #46 | CI beyond `ubuntu-latest`. Nothing has ever built or run on macOS or Windows, and the README documents a Windows config path. |
-| #47 | `tempfile` is a normal dependency but only used under `#[cfg(test)]`. |
+| ~~#45~~ | **Landed.** Package metadata, `license = "GPL-3.0-only"` matching the tree, `publish = false`, and `rust-version = "1.78"` — the floor the suite is verified against, with a CI job that keeps it true. |
+| ~~#46~~ | **Landed.** `test` is a matrix across Linux, macOS, and Windows; `fmt`/`clippy` split into a job that runs once. Dependabot enabled, monthly and grouped. |
+| ~~#47~~ | **Landed.** `tempfile` is a dev-dependency only. |
 | #44 | The release workflow itself: tag-triggered cross-platform binaries, checksums, generated notes, a real install section. |
-| #48 | The documented test count is an invariant nothing enforces, and two documents already disagree about it. |
+| ~~#48~~ | **Landed.** CI derives and prints per-binary and total test counts; the hand-maintained number is gone from the working notes. |
 
 #44 comes last of these on purpose: building binaries for platforms the suite
 has never run on, from a manifest that does not say what license they are
-under, is publishing guesses.
+under, is publishing guesses. Its prerequisites are now all in place — what it
+is waiting on is a decision about what a release contains, not more groundwork.
+
+Two things the release-engineering pass settled that are worth not
+re-litigating:
+
+- **The MSRV floor is 1.78 because of the lockfile, not the dependencies.**
+  The highest floor any dependency declares is clap's 1.70, and it is
+  unreachable: the committed `Cargo.lock` is lockfile v4, which no Cargo
+  before 1.78 can parse. Lowering the floor means regenerating the lockfile
+  in the older format, which is a deliberate choice and not a free one.
+- **The test count is reported, never enforced.** A hard failure on a
+  decreasing count also fires on legitimate consolidation, and a check people
+  learn to override is worse than no check. The direction of the number is the
+  signal.
 
 ## Phase 2 — dates and times
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,7 +33,7 @@ expensive the longer there is code depending on the answer.
 
 | Issue | What |
 | --- | --- |
-| ~~#45~~ | **Landed.** Package metadata, `license = "GPL-3.0-only"` matching the tree, `publish = false`, and `rust-version = "1.78"` — the floor the suite is verified against, with a CI job that keeps it true. |
+| ~~#45~~ | **Landed.** Package metadata, `license = "GPL-3.0-only"` matching the tree, and `rust-version = "1.78"` — the floor the suite is verified against, with a CI job that keeps it true. Left publishable, with `cargo publish --dry-run` in CI. |
 | ~~#46~~ | **Landed.** `test` is a matrix across Linux, macOS, and Windows; `fmt`/`clippy` split into a job that runs once. Dependabot enabled, monthly and grouped. |
 | ~~#47~~ | **Landed.** `tempfile` is a dev-dependency only. |
 | #44 | The release workflow itself: tag-triggered cross-platform binaries, checksums, generated notes, a real install section. |
@@ -56,6 +56,15 @@ re-litigating:
   decreasing count also fires on legitimate consolidation, and a check people
   learn to override is worse than no check. The direction of the number is the
   signal.
+- **The crate is kept publishable, and CI packages it on every run.** crates.io
+  is a possible destination rather than a settled one; `publish = false` would
+  have blocked the dry run too, letting the manifest rot unpublishable with
+  nothing to report it. One thing is still open and gets more expensive after
+  a first publish, not less: the package name (`trusty_rusty_todo_list`) and
+  the binary name (`trtodo`) differ, so installing would be
+  `cargo install trusty_rusty_todo_list` to get a `trtodo`. Both names were
+  unregistered when this was written, and neither is reserved by saying so —
+  publishing is the only thing that holds a name.
 
 ## Phase 2 — dates and times
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,10 +61,13 @@ re-litigating:
   have blocked the dry run too, letting the manifest rot unpublishable with
   nothing to report it. One thing is still open and gets more expensive after
   a first publish, not less: the package name (`trusty_rusty_todo_list`) and
-  the binary name (`trtodo`) differ, so installing would be
-  `cargo install trusty_rusty_todo_list` to get a `trtodo`. Both names were
-  unregistered when this was written, and neither is reserved by saying so —
-  publishing is the only thing that holds a name.
+  the binary name (`trt`) differ, so installing would be
+  `cargo install trusty_rusty_todo_list` to get a `trt`. They cannot be made
+  to match by renaming the package — `trt` on crates.io belongs to an
+  unrelated tokio runtime library. That crate ships no executable, so there is
+  no PATH collision; the clash is only over the crates.io namespace.
+  `trusty_rusty_todo_list` was unregistered when this was written, and saying
+  so reserves nothing — publishing is the only thing that holds a name.
 
 ## Phase 2 — dates and times
 

--- a/docs/WORKING-NOTES.md
+++ b/docs/WORKING-NOTES.md
@@ -18,7 +18,7 @@ how to spend fewer tokens getting the same work done.
 - **There is no lib target.** `cargo test --lib` fails outright with `no
   library targets found in package`. The unit tests live in the binary
   target alongside the integration tests. Use plain `cargo test`, or
-  `cargo test --bin trtodo` to skip the integration suites.
+  `cargo test --bin trt` to skip the integration suites.
 
 - **`rusqlite` is vendored with `features = ["bundled"]`**, so a cold build
   compiles SQLite from C source and takes minutes. A warm build takes
@@ -46,7 +46,7 @@ how to spend fewer tokens getting the same work done.
 - **A shared `CARGO_TARGET_DIR` across worktrees will lie to you.** Sharing one
   target directory between parallel worktrees looks like an easy way to avoid
   paying the bundled-`rusqlite` cold build more than once. It is not: every
-  worktree writes the same `debug/trtodo`, and the integration tests invoke
+  worktree writes the same `debug/trt`, and the integration tests invoke
   exactly that binary. Two agents building concurrently means one runs its
   tests against the other's binary, and the failures that produces are
   spurious and unreproducible. Give each worktree its own target directory and
@@ -87,7 +87,7 @@ exercises the features *against each other*, not just a merge that compiles.
 
 A subagent reporting "all tests pass" is a claim about whatever command it
 actually ran. One reported success here having run only `cargo test --bin
-trtodo`, which skips all seven integration suites — the exact place this
+trt`, which skips all seven integration suites — the exact place this
 project's regressions surface. Another reported a passing suite whose numbers
 came from a target directory a concurrent build was overwriting.
 

--- a/docs/WORKING-NOTES.md
+++ b/docs/WORKING-NOTES.md
@@ -30,8 +30,18 @@ how to spend fewer tokens getting the same work done.
   CI runs the strict form. A bare clippy run that looks clean proves
   nothing about whether CI will pass.
 
-- **Current state:** 173 tests across 7 binaries (111 unit + 15 + 3 + 14 + 7
-  + 6 + 17). If that total drops, something was deleted rather than fixed.
+- **CI reports the test count, per binary and total, in every run's job
+  summary.** If that total drops, something was deleted rather than fixed —
+  that is the one thing the number is for, and it is the direction of the
+  number that matters, not the value. It is deliberately not a coverage
+  target and deliberately not a hard CI failure; a build that breaks on a
+  decreasing count also breaks on legitimate consolidation, and then people
+  learn to override it.
+
+  The count is not repeated here on purpose. It used to be, and it drifted
+  into two different stale numbers in two documents — which is worse than no
+  number, because a written one gets quoted instead of re-derived. Read it
+  off the latest CI run, or `cargo test` locally.
 
 - **A shared `CARGO_TARGET_DIR` across worktrees will lie to you.** Sharing one
   target directory between parallel worktrees looks like an easy way to avoid

--- a/src/category_manager.rs
+++ b/src/category_manager.rs
@@ -3,7 +3,7 @@
 //! `CategoryManager` sits between the CLI and the `Storage` trait and owns all
 //! category behaviour described in the README: creating/renaming/deleting
 //! categories, the magic "Uncategorized" category (ID 0), custom ordering, and
-//! the category context set by `trtodo category use` which persists between
+//! the category context set by `trt category use` which persists between
 //! runs via `StorageData::current_category`.
 
 use crate::models::{Category, CategoryError, StorageError};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,12 +13,12 @@ pub enum Priority {
 pub struct Cli {
     /// Path to the configuration file to use instead of the default
     ///
-    /// Takes precedence over the `TRTODO_CONFIG` environment variable.
+    /// Takes precedence over the `TRT_CONFIG` environment variable.
     #[arg(
         long = "config",
         value_name = "PATH",
         global = true,
-        env = "TRTODO_CONFIG"
+        env = "TRT_CONFIG"
     )]
     pub config: Option<PathBuf>,
 
@@ -237,7 +237,7 @@ pub enum CategoryCommands {
 }
 
 /// The `deleted` namespace: everything you can do with the tasks that
-/// `trtodo delete` soft-deleted (the `deleted_at` timestamp).
+/// `trt delete` soft-deleted (the `deleted_at` timestamp).
 ///
 /// `list` and `restore` were previously absent on the grounds that the
 /// README documented only `flush`; the README now documents all three.
@@ -301,15 +301,15 @@ mod tests {
     #[test]
     fn test_config_path_override() {
         // Accepted before the subcommand.
-        let cli = parse_args(&["trtodo", "--config", "/tmp/x.json", "config", "list"]);
+        let cli = parse_args(&["trt", "--config", "/tmp/x.json", "config", "list"]);
         assert_eq!(cli.config, Some(PathBuf::from("/tmp/x.json")));
 
         // And after it, since the argument is global.
-        let cli = parse_args(&["trtodo", "config", "list", "--config", "/tmp/x.json"]);
+        let cli = parse_args(&["trt", "config", "list", "--config", "/tmp/x.json"]);
         assert_eq!(cli.config, Some(PathBuf::from("/tmp/x.json")));
 
         // Absent by default, so ConfigManager falls back to the $HOME location.
-        let cli = parse_args(&["trtodo", "config", "list"]);
+        let cli = parse_args(&["trt", "config", "list"]);
         assert_eq!(cli.config, None);
     }
 
@@ -318,27 +318,27 @@ mod tests {
     /// exclusive - "assume yes" and "assume no" cannot both hold.
     #[test]
     fn test_non_interactive_flags() {
-        let cli = parse_args(&["trtodo", "--yes", "list"]);
+        let cli = parse_args(&["trt", "--yes", "list"]);
         assert!(cli.yes);
         assert!(!cli.no_input);
 
-        let cli = parse_args(&["trtodo", "list", "-y"]);
+        let cli = parse_args(&["trt", "list", "-y"]);
         assert!(cli.yes);
 
-        let cli = parse_args(&["trtodo", "list", "--no-input"]);
+        let cli = parse_args(&["trt", "list", "--no-input"]);
         assert!(cli.no_input);
         assert!(!cli.yes);
 
-        let cli = parse_args(&["trtodo", "list"]);
+        let cli = parse_args(&["trt", "list"]);
         assert!(!cli.yes);
         assert!(!cli.no_input);
 
-        assert!(try_parse_args(&["trtodo", "--yes", "--no-input", "list"]).is_err());
+        assert!(try_parse_args(&["trt", "--yes", "--no-input", "list"]).is_err());
     }
 
     #[test]
     fn test_add_task() {
-        let cli = parse_args(&["trtodo", "add", "Buy milk", "--category", "Home"]);
+        let cli = parse_args(&["trt", "add", "Buy milk", "--category", "Home"]);
         match cli.command {
             Commands::Add {
                 title,
@@ -354,7 +354,7 @@ mod tests {
 
         // `--category` is optional: omitting it parses cleanly and
         // leaves resolution to `main::resolve_add_category`.
-        let cli = parse_args(&["trtodo", "add", "Buy milk"]);
+        let cli = parse_args(&["trt", "add", "Buy milk"]);
         match cli.command {
             Commands::Add {
                 title,
@@ -370,7 +370,7 @@ mod tests {
 
         // Test with priority
         let cli = parse_args(&[
-            "trtodo",
+            "trt",
             "add",
             "Buy milk",
             "--category",
@@ -395,7 +395,7 @@ mod tests {
     #[test]
     fn test_list_tasks() {
         // Test basic list
-        let cli = parse_args(&["trtodo", "list"]);
+        let cli = parse_args(&["trt", "list"]);
         match cli.command {
             Commands::List {
                 search,
@@ -411,7 +411,7 @@ mod tests {
 
         // Test list with all options
         let cli = parse_args(&[
-            "trtodo",
+            "trt",
             "list",
             "--search",
             "milk",
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn test_category_commands() {
         // Test category use
-        let cli = parse_args(&["trtodo", "category", "use", "Home"]);
+        let cli = parse_args(&["trt", "category", "use", "Home"]);
         match cli.command {
             Commands::Category { command } => match command {
                 CategoryCommands::Use { category } => {
@@ -448,7 +448,7 @@ mod tests {
         }
 
         // Test category list
-        let cli = parse_args(&["trtodo", "category", "list"]);
+        let cli = parse_args(&["trt", "category", "list"]);
         match cli.command {
             Commands::Category { command } => match command {
                 CategoryCommands::List => {}
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_category_order_command() {
-        let cli = parse_args(&["trtodo", "category", "order", "Work", "2"]);
+        let cli = parse_args(&["trt", "category", "order", "Work", "2"]);
         match cli.command {
             Commands::Category { command } => match command {
                 CategoryCommands::Order { category, position } => {
@@ -474,14 +474,14 @@ mod tests {
 
         // Position must parse as a non-negative integer; clap rejects
         // anything else before it ever reaches `main`.
-        assert!(try_parse_args(&["trtodo", "category", "order", "Work", "-1"]).is_err());
-        assert!(try_parse_args(&["trtodo", "category", "order", "Work", "nope"]).is_err());
-        assert!(try_parse_args(&["trtodo", "category", "order", "Work"]).is_err());
+        assert!(try_parse_args(&["trt", "category", "order", "Work", "-1"]).is_err());
+        assert!(try_parse_args(&["trt", "category", "order", "Work", "nope"]).is_err());
+        assert!(try_parse_args(&["trt", "category", "order", "Work"]).is_err());
     }
 
     #[test]
     fn test_category_reorder_command() {
-        let cli = parse_args(&["trtodo", "category", "reorder", "Work", "Home", "Personal"]);
+        let cli = parse_args(&["trt", "category", "reorder", "Work", "Home", "Personal"]);
         match cli.command {
             Commands::Category { command } => match command {
                 CategoryCommands::Reorder { categories } => {
@@ -500,7 +500,7 @@ mod tests {
         }
 
         // A single category is a legal (if degenerate) reorder.
-        let cli = parse_args(&["trtodo", "category", "reorder", "Work"]);
+        let cli = parse_args(&["trt", "category", "reorder", "Work"]);
         match cli.command {
             Commands::Category { command } => match command {
                 CategoryCommands::Reorder { categories } => {
@@ -516,13 +516,13 @@ mod tests {
     fn test_category_reorder_requires_at_least_one_category() {
         // An empty reorder has nothing to do and is refused at parse time
         // rather than accepted as a silent no-op.
-        assert!(try_parse_args(&["trtodo", "category", "reorder"]).is_err());
+        assert!(try_parse_args(&["trt", "category", "reorder"]).is_err());
     }
 
     #[test]
     fn test_config_commands() {
         // Test config set
-        let cli = parse_args(&["trtodo", "config", "set", "storage.type=json"]);
+        let cli = parse_args(&["trt", "config", "set", "storage.type=json"]);
         match cli.command {
             Commands::Config { command } => match command {
                 ConfigCommands::Set { key_value } => {
@@ -534,7 +534,7 @@ mod tests {
         }
 
         // Test config list
-        let cli = parse_args(&["trtodo", "config", "list"]);
+        let cli = parse_args(&["trt", "config", "list"]);
         match cli.command {
             Commands::Config { command } => match command {
                 ConfigCommands::List => {}
@@ -547,7 +547,7 @@ mod tests {
     #[test]
     fn test_deleted_commands() {
         // Test deleted list
-        let cli = parse_args(&["trtodo", "deleted", "list"]);
+        let cli = parse_args(&["trt", "deleted", "list"]);
         match cli.command {
             Commands::Deleted { command } => match command {
                 DeletedCommands::List => {}
@@ -557,7 +557,7 @@ mod tests {
         }
 
         // Test deleted restore
-        let cli = parse_args(&["trtodo", "deleted", "restore", "Buy milk"]);
+        let cli = parse_args(&["trt", "deleted", "restore", "Buy milk"]);
         match cli.command {
             Commands::Deleted { command } => match command {
                 DeletedCommands::Restore { title_or_id } => {
@@ -570,7 +570,7 @@ mod tests {
 
         // Test deleted flush: confirmation is opt-out, so `yes` is false
         // unless the escape hatch was passed.
-        let cli = parse_args(&["trtodo", "deleted", "flush"]);
+        let cli = parse_args(&["trt", "deleted", "flush"]);
         match cli.command {
             Commands::Deleted { command } => match command {
                 DeletedCommands::Flush { yes } => assert!(!yes),
@@ -581,7 +581,7 @@ mod tests {
 
         // ... in any of its three spellings.
         for flag in ["--yes", "-y", "--force"] {
-            let cli = parse_args(&["trtodo", "deleted", "flush", flag]);
+            let cli = parse_args(&["trt", "deleted", "flush", flag]);
             match cli.command {
                 Commands::Deleted { command } => match command {
                     DeletedCommands::Flush { yes } => assert!(yes, "{flag} should confirm"),
@@ -596,7 +596,7 @@ mod tests {
     fn test_deleted_restore_requires_a_task_reference() {
         // Nothing sensible to restore without one, and defaulting to "all"
         // would be a surprising thing to do by accident.
-        assert!(try_parse_args(&["trtodo", "deleted", "restore"]).is_err());
+        assert!(try_parse_args(&["trt", "deleted", "restore"]).is_err());
     }
 
     #[test]
@@ -606,16 +606,16 @@ mod tests {
         // can supply it. Parsing must therefore *succeed* without it - the
         // decision of where the task lands moved to `main`, which has the
         // storage and config access needed to make it.
-        let result = try_parse_args(&["trtodo", "add", "Buy milk"]);
+        let result = try_parse_args(&["trt", "add", "Buy milk"]);
         assert!(result.is_ok());
 
         // A title is still required, though: nothing can supply that.
-        let result = try_parse_args(&["trtodo", "add"]);
+        let result = try_parse_args(&["trt", "add"]);
         assert!(result.is_err());
 
         // Test that priority must be valid
         let result = try_parse_args(&[
-            "trtodo",
+            "trt",
             "add",
             "Buy milk",
             "--category",
@@ -629,7 +629,7 @@ mod tests {
     #[test]
     fn test_command_aliases() {
         // Test 'x' alias for check
-        let cli = parse_args(&["trtodo", "x", "Buy milk", "--category", "Home"]);
+        let cli = parse_args(&["trt", "x", "Buy milk", "--category", "Home"]);
         match cli.command {
             Commands::Check {
                 title_or_id,
@@ -642,7 +642,7 @@ mod tests {
         }
 
         // Test 'mark' alias for check
-        let cli = parse_args(&["trtodo", "mark", "Buy milk", "--category", "Home"]);
+        let cli = parse_args(&["trt", "mark", "Buy milk", "--category", "Home"]);
         match cli.command {
             Commands::Check {
                 title_or_id,
@@ -655,7 +655,7 @@ mod tests {
         }
 
         // Test 'o' alias for uncheck
-        let cli = parse_args(&["trtodo", "o", "Buy milk", "--category", "Home"]);
+        let cli = parse_args(&["trt", "o", "Buy milk", "--category", "Home"]);
         match cli.command {
             Commands::Uncheck {
                 title_or_id,
@@ -668,7 +668,7 @@ mod tests {
         }
 
         // Test 'unmark' alias for uncheck
-        let cli = parse_args(&["trtodo", "unmark", "Buy milk", "--category", "Home"]);
+        let cli = parse_args(&["trt", "unmark", "Buy milk", "--category", "Home"]);
         match cli.command {
             Commands::Uncheck {
                 title_or_id,
@@ -684,7 +684,7 @@ mod tests {
     #[test]
     fn test_move_commands() {
         // Test simple move syntax
-        let cli = parse_args(&["trtodo", "move", "Buy milk", "--to", "Shopping"]);
+        let cli = parse_args(&["trt", "move", "Buy milk", "--to", "Shopping"]);
         match cli.command {
             Commands::Move {
                 task_name_or_id,
@@ -702,7 +702,7 @@ mod tests {
 
         // Test extended move syntax
         let cli = parse_args(&[
-            "trtodo", "move", "--from", "Home", "--to", "Shopping", "--task", "Buy milk",
+            "trt", "move", "--from", "Home", "--to", "Shopping", "--task", "Buy milk",
         ]);
         match cli.command {
             Commands::Move {
@@ -720,7 +720,7 @@ mod tests {
         }
 
         // Test extended move syntax without target category (move to uncategorized)
-        let cli = parse_args(&["trtodo", "move", "--from", "Home", "--task", "Buy milk"]);
+        let cli = parse_args(&["trt", "move", "--from", "Home", "--task", "Buy milk"]);
         match cli.command {
             Commands::Move {
                 task_name_or_id,

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,7 +103,7 @@ fn validate_lifespan(value: &str) -> Result<u32, ConfigError> {
 // A `Config` value is used to represent two conceptually different things,
 // and keeping them straight is the whole point of this module:
 //
-// - "stored" config: what is actually written in `trtodo-config.json`. A
+// - "stored" config: what is actually written in `trt-config.json`. A
 //   `None` field here means *unset* - the user (or a fresh install) never
 //   wrote anything for it. This is what `ConfigStorage::load()` returns and
 //   what `config list`'s `*` markers are computed from.
@@ -250,7 +250,7 @@ fn default_storage_type() -> Option<String> {
 fn default_storage_path() -> Option<String> {
     dirs::home_dir().map(|home| {
         home.join(".config")
-            .join("trtodo")
+            .join("trt")
             .to_string_lossy()
             .to_string()
     })
@@ -270,9 +270,7 @@ impl ConfigManager {
             path.to_path_buf()
         } else {
             let home = dirs::home_dir().expect("Could not determine home directory");
-            home.join(".config")
-                .join("trtodo")
-                .join("trtodo-config.json")
+            home.join(".config").join("trt").join("trt-config.json")
         };
 
         let storage =
@@ -493,7 +491,7 @@ mod tests {
         assert_eq!(manager.get("storage.type"), Some("json".to_string()));
 
         // Test setting storage path
-        let storage_path = "~/.config/trtodo";
+        let storage_path = "~/.config/trt";
         assert!(manager.set("storage.path", storage_path).is_ok());
         assert_eq!(
             manager.get("storage.path"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -490,12 +490,30 @@ mod tests {
         assert!(manager.set("storage.type", "json").is_ok());
         assert_eq!(manager.get("storage.type"), Some("json".to_string()));
 
-        // Test setting storage path
-        let storage_path = "~/.config/trt";
-        assert!(manager.set("storage.path", storage_path).is_ok());
+        // Test setting storage path.
+        //
+        // The path comes from the TempDir rather than a hardcoded
+        // `~/.config/...` because `validate_storage_path` rejects a path whose
+        // parent does not exist. `~/.config` is a Unix convention that happens
+        // to exist on the Linux and macOS runners and does not exist on a
+        // fresh Windows one, so hardcoding it made this assert on ambient
+        // filesystem state rather than on the code under test.
+        let storage_path = temp_dir
+            .path()
+            .join("storage")
+            .to_string_lossy()
+            .to_string();
+        assert!(manager.set("storage.path", &storage_path).is_ok());
+        assert_eq!(manager.get("storage.path"), Some(storage_path));
+
+        // Tilde expansion is part of the contract, so it keeps its own
+        // assertion - against `~` itself, which resolves to the home directory
+        // on every platform and whose parent (`/home`, `/Users`, `C:\Users`)
+        // therefore exists on every platform.
+        assert!(manager.set("storage.path", "~").is_ok());
         assert_eq!(
             manager.get("storage.path"),
-            Some(shellexpand::tilde(storage_path).to_string())
+            Some(shellexpand::tilde("~").to_string())
         );
 
         // Test setting default category

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ fn main() {
 fn run() -> Result<(), CliError> {
     let cli = Cli::parse();
 
-    // Initialize config manager, honoring an explicit --config / TRTODO_CONFIG
+    // Initialize config manager, honoring an explicit --config / TRT_CONFIG
     // override so callers (and tests) can point at a config file outside $HOME.
     let mut config_manager = ConfigManager::new(cli.config.as_deref())?;
 
@@ -209,7 +209,7 @@ const DEFAULT_CATEGORIES: [&str; 2] = ["Home", "Work"];
 ///
 /// This is the *only* path to task storage from `run`, which is what decides
 /// the answer to "which commands trigger the offer?": every command that
-/// touches tasks or categories does, and `trtodo config ...` - the one
+/// touches tasks or categories does, and `trt config ...` - the one
 /// command group that never opens task storage - does not. That is
 /// deliberate:
 ///
@@ -236,7 +236,7 @@ fn open_task_storage(
 }
 
 /// Offers to create the README's default "Home" and "Work" categories the
-/// first time `trtodo` touches task storage.
+/// first time `trt` touches task storage.
 ///
 /// "First run" is a *config* fact, not a storage fact: the marker written by
 /// `ConfigManager::record_default_categories_offer` records that the offer
@@ -286,7 +286,7 @@ fn offer_default_categories(
             println!("Category '{}' added with ID {}", name, id);
         }
     } else {
-        println!("Skipped; add categories yourself with 'trtodo category add <name>'");
+        println!("Skipped; add categories yourself with 'trt category add <name>'");
     }
 
     config_manager.record_default_categories_offer()?;
@@ -296,7 +296,7 @@ fn offer_default_categories(
 /// Builds the task storage backend described by the current configuration.
 ///
 /// `storage.path` is the storage *location* (a directory, per the README's
-/// `~/.config/trtodo` default); the data file inside it is named after the
+/// `~/.config/trt` default); the data file inside it is named after the
 /// chosen backend.
 ///
 /// Also sweeps up anything overdue for automatic purging under
@@ -336,7 +336,7 @@ fn storage_dir(config_manager: &ConfigManager) -> Result<PathBuf, CliError> {
         None => Ok(dirs::home_dir()
             .ok_or(CliError::NoHomeDirectory)?
             .join(".config")
-            .join("trtodo")),
+            .join("trt")),
     }
 }
 
@@ -428,7 +428,7 @@ fn carry_data_across_backend_switch(
                 e
             );
             eprintln!(
-                "Warning: the file has been left untouched. Run 'trtodo config set \
+                "Warning: the file has been left untouched. Run 'trt config set \
                  storage.type={}' to go back to it.",
                 old_type.as_str()
             );
@@ -468,7 +468,7 @@ fn carry_data_across_backend_switch(
                 if categories == 1 { "y" } else { "ies" }
             );
             eprintln!(
-                "Warning: your {} data is still intact at {}. Run 'trtodo config set \
+                "Warning: your {} data is still intact at {}. Run 'trt config set \
                  storage.type={}' to go back to it.",
                 old_type.as_str(),
                 old_file.display(),
@@ -608,7 +608,7 @@ fn run_category_command(
     Ok(())
 }
 
-/// Dispatches `trtodo deleted ...`. Mirrors `run_category_command`'s shape.
+/// Dispatches `trt deleted ...`. Mirrors `run_category_command`'s shape.
 ///
 /// Unlike that function this also needs a `CategoryManager`: soft-deleted
 /// tasks keep their real `category_id`, and both `list` and

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -81,14 +81,14 @@ impl Task {
     /// Un-deletes the task. Because `soft_delete` never touched
     /// `category_id`, this is all a restore takes - the task goes straight
     /// back where it came from. Reachable from the CLI as
-    /// `trtodo deleted restore <title or id>`.
+    /// `trt deleted restore <title or id>`.
     pub fn restore(&mut self) {
         self.deleted_at = None;
         self.updated_at = Utc::now();
     }
 
     /// The deletion timestamp rendered for humans: the "deleted" column of
-    /// `trtodo deleted list`, the flush preview, and the restore
+    /// `trt deleted list`, the flush preview, and the restore
     /// disambiguation prompt all share this one format so the same task
     /// looks the same wherever it is shown.
     ///
@@ -246,7 +246,7 @@ impl StorageData {
             tasks: Vec::new(),
             categories: Vec::new(),
             // The `config` field embedded in the task-data file is
-            // vestigial - the real config lives in `trtodo-config.json` via
+            // vestigial - the real config lives in `trt-config.json` via
             // `ConfigStorage`. `Config::unset()` (nothing stored) is the
             // honest value here; resolving it to the documented defaults
             // would make this file start carrying a populated config blob

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -102,7 +102,7 @@ mod tests {
             config: Config {
                 deleted_task_lifespan: Some(7),
                 storage_type: Some("json".to_string()),
-                storage_path: Some("~/.config/trtodo".to_string()),
+                storage_path: Some("~/.config/trt".to_string()),
                 default_category: Some("work".to_string()),
                 default_priority: Some("medium".to_string()),
                 default_categories_offered: Some(true),
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(loaded_data.config.storage_type, Some("json".to_string()));
         assert_eq!(
             loaded_data.config.storage_path,
-            Some("~/.config/trtodo".to_string())
+            Some("~/.config/trt".to_string())
         );
         assert_eq!(
             loaded_data.config.default_category,

--- a/src/storage/json.rs
+++ b/src/storage/json.rs
@@ -25,8 +25,8 @@ impl JsonStorage {
     ///
     /// This makes the guarantee local to the backend instead of depending on a
     /// filename convention maintained elsewhere. While normal configuration
-    /// routes each backend to a distinct file (`trtodo-data.json` vs
-    /// `trtodo-data.db`), a direct `JsonStorage::new(...)` call with an
+    /// routes each backend to a distinct file (`trt-data.json` vs
+    /// `trt-data.db`), a direct `JsonStorage::new(...)` call with an
     /// arbitrary path can reach any file. The check closes that gap.
     fn validate_target_format(&self) -> Result<(), StorageError> {
         if !self.path.exists() {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -51,8 +51,8 @@ impl StorageType {
     /// deal with.
     pub fn data_file_name(self) -> &'static str {
         match self {
-            StorageType::Json => "trtodo-data.json",
-            StorageType::Sqlite => "trtodo-data.db",
+            StorageType::Json => "trt-data.json",
+            StorageType::Sqlite => "trt-data.db",
         }
     }
 }
@@ -466,8 +466,8 @@ mod tests {
     #[test]
     fn test_migrate_storage_carries_data_across_backends() {
         let dir = TempDir::new().unwrap();
-        let json_path = dir.path().join("trtodo-data.json");
-        let sqlite_path = dir.path().join("trtodo-data.db");
+        let json_path = dir.path().join("trt-data.json");
+        let sqlite_path = dir.path().join("trt-data.db");
 
         let source = create_storage(StorageType::Json, &json_path).unwrap();
         source.save(&populated_data()).unwrap();
@@ -513,12 +513,11 @@ mod tests {
     #[test]
     fn test_migrate_storage_carries_data_back_from_sqlite_to_json() {
         let dir = TempDir::new().unwrap();
-        let source =
-            create_storage(StorageType::Sqlite, &dir.path().join("trtodo-data.db")).unwrap();
+        let source = create_storage(StorageType::Sqlite, &dir.path().join("trt-data.db")).unwrap();
         source.save(&populated_data()).unwrap();
 
         let destination =
-            create_storage(StorageType::Json, &dir.path().join("trtodo-data.json")).unwrap();
+            create_storage(StorageType::Json, &dir.path().join("trt-data.json")).unwrap();
         assert_eq!(
             migrate_storage(&*source, &*destination).unwrap(),
             MigrationOutcome::Migrated {
@@ -540,8 +539,8 @@ mod tests {
     #[test]
     fn test_migrate_storage_never_clobbers_a_non_empty_destination() {
         let dir = TempDir::new().unwrap();
-        let json_path = dir.path().join("trtodo-data.json");
-        let sqlite_path = dir.path().join("trtodo-data.db");
+        let json_path = dir.path().join("trt-data.json");
+        let sqlite_path = dir.path().join("trt-data.db");
 
         let source = create_storage(StorageType::Sqlite, &sqlite_path).unwrap();
         source.save(&populated_data()).unwrap();
@@ -581,8 +580,8 @@ mod tests {
     #[test]
     fn test_migrate_storage_reports_an_empty_source_without_writing() {
         let dir = TempDir::new().unwrap();
-        let json_path = dir.path().join("trtodo-data.json");
-        let sqlite_path = dir.path().join("trtodo-data.db");
+        let json_path = dir.path().join("trt-data.json");
+        let sqlite_path = dir.path().join("trt-data.db");
 
         let source = create_storage(StorageType::Json, &json_path).unwrap();
         let destination = create_storage(StorageType::Sqlite, &sqlite_path).unwrap();
@@ -601,15 +600,14 @@ mod tests {
     #[test]
     fn test_migrate_storage_carries_soft_deleted_tasks_too() {
         let dir = TempDir::new().unwrap();
-        let source =
-            create_storage(StorageType::Json, &dir.path().join("trtodo-data.json")).unwrap();
+        let source = create_storage(StorageType::Json, &dir.path().join("trt-data.json")).unwrap();
 
         let mut data = populated_data();
         data.tasks[0].soft_delete();
         source.save(&data).unwrap();
 
         let destination =
-            create_storage(StorageType::Sqlite, &dir.path().join("trtodo-data.db")).unwrap();
+            create_storage(StorageType::Sqlite, &dir.path().join("trt-data.db")).unwrap();
         assert_eq!(
             migrate_storage(&*source, &*destination).unwrap(),
             MigrationOutcome::Migrated {
@@ -936,7 +934,7 @@ mod tests {
     /// The automatic sweep runs on *every* invocation (see
     /// `main::open_storage`), so when there is nothing overdue it must leave
     /// the data file completely alone rather than rewriting it. Otherwise a
-    /// read-only `trtodo list` would rewrite storage on every run whenever a
+    /// read-only `trt list` would rewrite storage on every run whenever a
     /// non-zero `deleted-task-lifespan` is configured.
     #[test]
     fn test_purge_deleted_tasks_does_not_rewrite_storage_when_nothing_is_due() {

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -134,9 +134,9 @@ impl SqliteStorage {
         if let Some(version) = stored_version {
             if version > SCHEMA_VERSION {
                 return Err(StorageError::Storage(format!(
-                    "this database uses schema version {}, but this build of trtodo only \
+                    "this database uses schema version {}, but this build of trt only \
                      understands up to version {}; it was most likely written by a newer \
-                     version of trtodo. Upgrade trtodo, or point storage.path at a different \
+                     version of trt. Upgrade trt, or point storage.path at a different \
                      directory. The database has not been modified.",
                     version, SCHEMA_VERSION
                 )));
@@ -849,7 +849,7 @@ mod tests {
             "the error should name both the version found and the version supported, got: {message}"
         );
         assert!(
-            message.contains("newer version of trtodo"),
+            message.contains("newer version of trt"),
             "the error should explain *why* this happened, got: {message}"
         );
 

--- a/src/storage/test_utils.rs
+++ b/src/storage/test_utils.rs
@@ -20,7 +20,7 @@ pub struct TestStorage {
 impl TestStorage {
     pub fn new() -> Self {
         let temp_dir = tempfile::Builder::new()
-            .prefix("trtodo_test")
+            .prefix("trt_test")
             .tempdir()
             .expect("failed to create temporary directory");
 

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -6,7 +6,7 @@
 //! filtered listing, and the "match by name, prompt if ambiguous" rule (see
 //! `crate::prompter`).
 //!
-//! It also owns the *deleted* side of that world (`trtodo deleted ...`):
+//! It also owns the *deleted* side of that world (`trt deleted ...`):
 //! listing what is soft-deleted, resolving a reference among only those
 //! tasks, restoring one, and flushing them all. Those live here rather than
 //! in a module of their own because they are the same tasks under a
@@ -159,7 +159,7 @@ impl<'a> TaskManager<'a> {
     }
 
     /// Every currently soft-deleted task, oldest deletion first
-    /// (`trtodo deleted list`).
+    /// (`trt deleted list`).
     ///
     /// Sorted by `deleted_at` deliberately: this list doubles as the preview
     /// of what a `flush` would destroy and of what the automatic
@@ -174,7 +174,7 @@ impl<'a> TaskManager<'a> {
     }
 
     /// Resolves a `<title or id>` CLI argument to a single *soft-deleted*
-    /// task, for `trtodo deleted restore`.
+    /// task, for `trt deleted restore`.
     ///
     /// This is the inverse scope of `resolve_task`, and it has to be its own
     /// method rather than a flag on that one: every title/ID lookup helper
@@ -256,7 +256,7 @@ impl<'a> TaskManager<'a> {
     }
 
     /// Permanently removes every currently soft-deleted task, unconditionally
-    /// (`trtodo deleted flush`). See `Storage::purge_all_deleted_tasks` for
+    /// (`trt deleted flush`). See `Storage::purge_all_deleted_tasks` for
     /// why this is a distinct primitive from the automatic,
     /// `deleted-task-lifespan`-gated purge below.
     ///

--- a/tests/category_commands.rs
+++ b/tests/category_commands.rs
@@ -1,22 +1,22 @@
-//! End-to-end coverage of `trtodo category ...`.
+//! End-to-end coverage of `trt category ...`.
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, and
 //! that config points `storage.path` at the same `TempDir`, so the real
-//! `~/.config/trtodo` is never read or written.
+//! `~/.config/trt` is never read or written.
 
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-struct Trtodo {
+struct Trt {
     _dir: TempDir,
     config_path: std::path::PathBuf,
 }
 
-impl Trtodo {
+impl Trt {
     fn new() -> Self {
         let dir = TempDir::new().unwrap();
-        let config_path = dir.path().join("trtodo-config.json");
+        let config_path = dir.path().join("trt-config.json");
         let this = Self {
             config_path,
             _dir: dir,
@@ -33,21 +33,21 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trtodo"))
+        Command::new(env!("CARGO_BIN_EXE_trt"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.
             .env("HOME", self.home_guard())
             .args(args)
             .output()
-            .expect("failed to run trtodo")
+            .expect("failed to run trt")
     }
 
     /// A path that does not exist: if any code path tries to use `$HOME`
     /// instead of the configured storage location, the test fails loudly
     /// instead of touching the developer's real config.
     fn home_guard(&self) -> &Path {
-        Path::new("/nonexistent-trtodo-test-home")
+        Path::new("/nonexistent-trt-test-home")
     }
 
     fn ok(&self, args: &[&str]) -> String {
@@ -74,36 +74,36 @@ impl Trtodo {
 
 #[test]
 fn category_lifecycle() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
     // Add
-    let out = trtodo.ok(&["category", "add", "Work"]);
+    let out = trt.ok(&["category", "add", "Work"]);
     assert!(out.contains("added with ID 1"), "{out}");
-    trtodo.ok(&["category", "add", "Home"]);
+    trt.ok(&["category", "add", "Home"]);
 
     // List includes the magic Uncategorized category first
-    let out = trtodo.ok(&["category", "list"]);
+    let out = trt.ok(&["category", "list"]);
     assert!(out.contains("0: Uncategorized (current)"), "{out}");
     assert!(out.contains("1: Work"), "{out}");
     assert!(out.contains("2: Home"), "{out}");
 
     // Duplicate names are rejected
-    let err = trtodo.fail(&["category", "add", "work"]);
+    let err = trt.fail(&["category", "add", "work"]);
     assert!(err.contains("already exists"), "{err}");
 
     // Update
-    trtodo.ok(&["category", "update", "Home", "Personal"]);
-    let out = trtodo.ok(&["category", "list"]);
+    trt.ok(&["category", "update", "Home", "Personal"]);
+    let out = trt.ok(&["category", "list"]);
     assert!(out.contains("2: Personal"), "{out}");
     assert!(!out.contains("Home"), "{out}");
 
     // Delete frees the ID again
-    trtodo.ok(&["category", "delete", "Work"]);
-    let out = trtodo.ok(&["category", "add", "Errands"]);
+    trt.ok(&["category", "delete", "Work"]);
+    let out = trt.ok(&["category", "add", "Errands"]);
     assert!(out.contains("added with ID 1"), "{out}");
 
     // Unknown categories are a clean error, not a panic
-    let err = trtodo.fail(&["category", "delete", "Nope"]);
+    let err = trt.fail(&["category", "delete", "Nope"]);
     assert!(err.starts_with("error: "), "{err}");
     assert!(err.contains("Nope"), "{err}");
 }
@@ -113,26 +113,26 @@ fn category_lifecycle() {
 /// resolves to anything.
 #[test]
 fn category_update_carries_default_category_along() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["config", "set", "default-category=Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["config", "set", "default-category=Work"]);
 
-    let out = trtodo.ok(&["category", "update", "Work", "Werk"]);
+    let out = trt.ok(&["category", "update", "Work", "Werk"]);
     assert!(
         out.contains("Updated config 'default-category' to 'Werk'"),
         "{out}"
     );
 
     // The setting now names the renamed category...
-    let out = trtodo.ok(&["config", "list"]);
+    let out = trt.ok(&["config", "list"]);
     assert!(out.contains("default-category = Werk"), "{out}");
 
     // ...and a bare `add` resolves it rather than erroring, landing the task
     // in the renamed category.
-    let out = trtodo.ok(&["add", "Buy milk"]);
+    let out = trt.ok(&["add", "Buy milk"]);
     assert!(out.contains("in category 'Werk'"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(
         out.contains("Buy milk (priority: medium, category: Werk)"),
         "{out}"
@@ -143,15 +143,15 @@ fn category_update_carries_default_category_along() {
 /// only a rename of the category it actually names carries it along.
 #[test]
 fn category_update_leaves_unrelated_default_category_alone() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["config", "set", "default-category=Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["config", "set", "default-category=Work"]);
 
-    let out = trtodo.ok(&["category", "update", "Home", "Personal"]);
+    let out = trt.ok(&["category", "update", "Home", "Personal"]);
     assert!(!out.contains("default-category"), "{out}");
 
-    let out = trtodo.ok(&["config", "list"]);
+    let out = trt.ok(&["config", "list"]);
     assert!(out.contains("default-category = Work"), "{out}");
 }
 
@@ -159,13 +159,13 @@ fn category_update_leaves_unrelated_default_category_alone() {
 /// must not fabricate a value.
 #[test]
 fn category_update_with_no_default_category_set_is_a_no_op_for_config() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
 
-    let out = trtodo.ok(&["category", "update", "Work", "Werk"]);
+    let out = trt.ok(&["category", "update", "Work", "Werk"]);
     assert!(!out.contains("default-category"), "{out}");
 
-    let out = trtodo.ok(&["config", "list"]);
+    let out = trt.ok(&["config", "list"]);
     assert!(out.contains("*default-category = null"), "{out}");
 }
 
@@ -175,58 +175,58 @@ fn category_update_with_no_default_category_set_is_a_no_op_for_config() {
 /// resolution).
 #[test]
 fn category_update_matches_default_category_case_insensitively() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["config", "set", "default-category=work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["config", "set", "default-category=work"]);
 
-    let out = trtodo.ok(&["category", "update", "Work", "Werk"]);
+    let out = trt.ok(&["category", "update", "Work", "Werk"]);
     assert!(
         out.contains("Updated config 'default-category' to 'Werk'"),
         "{out}"
     );
 
-    let out = trtodo.ok(&["config", "list"]);
+    let out = trt.ok(&["config", "list"]);
     assert!(out.contains("default-category = Werk"), "{out}");
 }
 
 #[test]
 fn category_context_persists_between_runs() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
 
     // No context yet
-    let out = trtodo.ok(&["category", "show"]);
+    let out = trt.ok(&["category", "show"]);
     assert!(out.contains("Uncategorized (ID: 0)"), "{out}");
 
     // Set context - and it survives into the *next* process invocation
-    trtodo.ok(&["category", "use", "Work"]);
-    let out = trtodo.ok(&["category", "show"]);
+    trt.ok(&["category", "use", "Work"]);
+    let out = trt.ok(&["category", "show"]);
     assert!(out.contains("Current category: Work (ID: 1)"), "{out}");
 
-    let out = trtodo.ok(&["category", "list"]);
+    let out = trt.ok(&["category", "list"]);
     assert!(out.contains("1: Work (current)"), "{out}");
 
     // Categories can also be referenced by ID
-    trtodo.ok(&["category", "clear"]);
-    trtodo.ok(&["category", "use", "1"]);
-    let out = trtodo.ok(&["category", "show"]);
+    trt.ok(&["category", "clear"]);
+    trt.ok(&["category", "use", "1"]);
+    let out = trt.ok(&["category", "show"]);
     assert!(out.contains("Current category: Work (ID: 1)"), "{out}");
 
     // Clear
-    trtodo.ok(&["category", "clear"]);
-    let out = trtodo.ok(&["category", "show"]);
+    trt.ok(&["category", "clear"]);
+    let out = trt.ok(&["category", "show"]);
     assert!(out.contains("Uncategorized (ID: 0)"), "{out}");
 }
 
 #[test]
 fn category_context_persists_with_sqlite_backend() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+    let trt = Trt::new();
+    trt.ok(&["config", "set", "storage.type=sqlite"]);
 
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "use", "Work"]);
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "use", "Work"]);
 
-    let out = trtodo.ok(&["category", "show"]);
+    let out = trt.ok(&["category", "show"]);
     assert!(out.contains("Current category: Work (ID: 1)"), "{out}");
 }
 
@@ -242,25 +242,25 @@ fn list_order(out: &str) -> Vec<String> {
 
 #[test]
 fn category_order_changes_list_position() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]); // ID 1, default order 1
-    trtodo.ok(&["category", "add", "Home"]); // ID 2, default order 2
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]); // ID 1, default order 1
+    trt.ok(&["category", "add", "Home"]); // ID 2, default order 2
 
     // Before: Uncategorized, Work, Home
-    let out = list_order(&trtodo.ok(&["category", "list"]));
+    let out = list_order(&trt.ok(&["category", "list"]));
     assert_eq!(
         out,
         vec!["0: Uncategorized (current)", "1: Work", "2: Home"]
     );
 
     // Move Home ahead of Work.
-    let msg = trtodo.ok(&["category", "order", "Home", "1"]);
+    let msg = trt.ok(&["category", "order", "Home", "1"]);
     assert!(msg.contains("Home") && msg.contains("position 1"), "{msg}");
 
     // Home (order 1) now ties Work's default order (1); "Home" < "Work"
     // alphabetically, so Home sorts first among the tied pair. IDs never
     // move, only list position does - Home stays ID 2, Work stays ID 1.
-    let out = list_order(&trtodo.ok(&["category", "list"]));
+    let out = list_order(&trt.ok(&["category", "list"]));
     assert_eq!(
         out,
         vec!["0: Uncategorized (current)", "2: Home", "1: Work"]
@@ -269,12 +269,12 @@ fn category_order_changes_list_position() {
 
 #[test]
 fn category_order_works_by_id() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]); // ID 1
-    trtodo.ok(&["category", "add", "Home"]); // ID 2
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]); // ID 1
+    trt.ok(&["category", "add", "Home"]); // ID 2
 
-    trtodo.ok(&["category", "order", "2", "1"]);
-    let out = list_order(&trtodo.ok(&["category", "list"]));
+    trt.ok(&["category", "order", "2", "1"]);
+    let out = list_order(&trt.ok(&["category", "list"]));
     assert_eq!(
         out,
         vec!["0: Uncategorized (current)", "2: Home", "1: Work"]
@@ -283,18 +283,18 @@ fn category_order_works_by_id() {
 
 #[test]
 fn category_reorder_sets_several_at_once() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]); // ID 1
-    trtodo.ok(&["category", "add", "Home"]); // ID 2
-    trtodo.ok(&["category", "add", "Errands"]); // ID 3
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]); // ID 1
+    trt.ok(&["category", "add", "Home"]); // ID 2
+    trt.ok(&["category", "add", "Errands"]); // ID 3
 
-    let msg = trtodo.ok(&["category", "reorder", "Errands", "Home", "Work"]);
+    let msg = trt.ok(&["category", "reorder", "Errands", "Home", "Work"]);
     assert!(
         msg.contains("Errands, Home, Work"),
         "expected the reordered names echoed back: {msg}"
     );
 
-    let out = list_order(&trtodo.ok(&["category", "list"]));
+    let out = list_order(&trt.ok(&["category", "list"]));
     assert_eq!(
         out,
         vec![
@@ -308,16 +308,16 @@ fn category_reorder_sets_several_at_once() {
 
 #[test]
 fn category_reorder_partial_list_leaves_others_where_they_were() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]); // ID 1, default order 1
-    trtodo.ok(&["category", "add", "Home"]); // ID 2, default order 2
-    trtodo.ok(&["category", "add", "Errands"]); // ID 3, default order 3
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]); // ID 1, default order 1
+    trt.ok(&["category", "add", "Home"]); // ID 2, default order 2
+    trt.ok(&["category", "add", "Errands"]); // ID 3, default order 3
 
     // Only reorder Home and Errands; Work is left with its default order
     // (1), which ties Errands' newly assigned order (also 1).
-    trtodo.ok(&["category", "reorder", "Errands", "Home"]);
+    trt.ok(&["category", "reorder", "Errands", "Home"]);
 
-    let out = list_order(&trtodo.ok(&["category", "list"]));
+    let out = list_order(&trt.ok(&["category", "list"]));
     // Errands and Work both land on order 1; "Errands" < "Work"
     // alphabetically breaks the tie. Home was assigned order 2.
     assert_eq!(
@@ -333,45 +333,45 @@ fn category_reorder_partial_list_leaves_others_where_they_were() {
 
 #[test]
 fn category_order_rejects_uncategorized() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    let err = trtodo.fail(&["category", "order", "Uncategorized", "1"]);
+    let err = trt.fail(&["category", "order", "Uncategorized", "1"]);
     assert!(err.contains("cannot be reordered"), "{err}");
 
-    let err = trtodo.fail(&["category", "order", "0", "1"]);
+    let err = trt.fail(&["category", "order", "0", "1"]);
     assert!(err.contains("cannot be reordered"), "{err}");
 
-    let err = trtodo.fail(&["category", "reorder", "Uncategorized"]);
+    let err = trt.fail(&["category", "reorder", "Uncategorized"]);
     assert!(err.contains("cannot be reordered"), "{err}");
 }
 
 #[test]
 fn category_order_rejects_invalid_positions() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
 
     // 0 is out of range: positions are 1-based.
-    let err = trtodo.fail(&["category", "order", "Work", "0"]);
+    let err = trt.fail(&["category", "order", "Work", "0"]);
     assert!(err.contains("1-based"), "{err}");
 
     // Not a number at all - rejected by clap before it reaches `main`.
-    trtodo.fail(&["category", "order", "Work", "nope"]);
+    trt.fail(&["category", "order", "Work", "nope"]);
 
     // Unknown category name is a clean error, not a panic.
-    let err = trtodo.fail(&["category", "order", "NoSuchCategory", "1"]);
+    let err = trt.fail(&["category", "order", "NoSuchCategory", "1"]);
     assert!(err.contains("NoSuchCategory"), "{err}");
 }
 
 #[test]
 fn category_order_persists_with_sqlite_backend() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+    let trt = Trt::new();
+    trt.ok(&["config", "set", "storage.type=sqlite"]);
 
-    trtodo.ok(&["category", "add", "Work"]); // ID 1
-    trtodo.ok(&["category", "add", "Home"]); // ID 2
-    trtodo.ok(&["category", "order", "Home", "1"]);
+    trt.ok(&["category", "add", "Work"]); // ID 1
+    trt.ok(&["category", "add", "Home"]); // ID 2
+    trt.ok(&["category", "order", "Home", "1"]);
 
-    let out = list_order(&trtodo.ok(&["category", "list"]));
+    let out = list_order(&trt.ok(&["category", "list"]));
     assert_eq!(
         out,
         vec!["0: Uncategorized (current)", "2: Home", "1: Work"]
@@ -380,16 +380,16 @@ fn category_order_persists_with_sqlite_backend() {
 
 #[test]
 fn category_reorder_persists_with_sqlite_backend() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+    let trt = Trt::new();
+    trt.ok(&["config", "set", "storage.type=sqlite"]);
 
-    trtodo.ok(&["category", "add", "Work"]); // ID 1
-    trtodo.ok(&["category", "add", "Home"]); // ID 2
-    trtodo.ok(&["category", "add", "Errands"]); // ID 3
+    trt.ok(&["category", "add", "Work"]); // ID 1
+    trt.ok(&["category", "add", "Home"]); // ID 2
+    trt.ok(&["category", "add", "Errands"]); // ID 3
 
-    trtodo.ok(&["category", "reorder", "Errands", "Home", "Work"]);
+    trt.ok(&["category", "reorder", "Errands", "Home", "Work"]);
 
-    let out = list_order(&trtodo.ok(&["category", "list"]));
+    let out = list_order(&trt.ok(&["category", "list"]));
     assert_eq!(
         out,
         vec![

--- a/tests/config_commands.rs
+++ b/tests/config_commands.rs
@@ -105,8 +105,14 @@ fn fresh_install_reports_documented_defaults() {
     );
     let (_, storage_path, is_default) = find(&entries, "storage.path");
     assert!(*is_default, "{out}");
+    // Compared as path components rather than as a string suffix. The value is
+    // rendered with the platform's separator, so a literal "/.config/trt"
+    // asserts the separator as much as the path and fails on Windows against a
+    // perfectly correct `C:\Users\...\.config\trt`. `Path::ends_with` matches
+    // whole components and is separator-agnostic.
+    let expected_tail = Path::new(".config").join("trt");
     assert!(
-        storage_path.ends_with("/.config/trt"),
+        Path::new(storage_path).ends_with(&expected_tail),
         "expected an expanded ~/.config/trt path, got {storage_path}"
     );
     assert_eq!(

--- a/tests/config_commands.rs
+++ b/tests/config_commands.rs
@@ -1,27 +1,27 @@
-//! End-to-end coverage of `trtodo config ...`, pinning down that declared
+//! End-to-end coverage of `trt config ...`, pinning down that declared
 //! config defaults are actually applied.
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, and
 //! `$HOME` is pointed at a path that doesn't exist, so the real
-//! `~/.config/trtodo` and the developer's actual config/todo data are never
+//! `~/.config/trt` and the developer's actual config/todo data are never
 //! read or written.
 
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-struct Trtodo {
+struct Trt {
     _dir: TempDir,
     config_path: std::path::PathBuf,
 }
 
-impl Trtodo {
+impl Trt {
     /// A fresh instance with no config file yet - this is the "clean $HOME"
     /// scenario the issue is about, so unlike `category_commands.rs` this
     /// constructor deliberately does *not* seed any config.
     fn new() -> Self {
         let dir = TempDir::new().unwrap();
-        let config_path = dir.path().join("trtodo-config.json");
+        let config_path = dir.path().join("trt-config.json");
         Self {
             config_path,
             _dir: dir,
@@ -29,21 +29,21 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trtodo"))
+        Command::new(env!("CARGO_BIN_EXE_trt"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.
             .env("HOME", self.home_guard())
             .args(args)
             .output()
-            .expect("failed to run trtodo")
+            .expect("failed to run trt")
     }
 
     /// A path that does not exist: if any code path tries to use `$HOME`
     /// instead of the configured storage location, the test fails loudly
     /// instead of touching the developer's real config.
     fn home_guard(&self) -> &Path {
-        Path::new("/nonexistent-trtodo-test-home")
+        Path::new("/nonexistent-trt-test-home")
     }
 
     fn ok(&self, args: &[&str]) -> String {
@@ -85,13 +85,13 @@ fn find<'a>(entries: &'a [(String, String, bool)], key: &str) -> &'a (String, St
 /// primary regression test for defaults being declared but never applied.
 #[test]
 fn fresh_install_reports_documented_defaults() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
     assert!(
-        !trtodo.config_path.exists(),
+        !trt.config_path.exists(),
         "test setup should not have created a config file"
     );
 
-    let out = trtodo.ok(&["config", "list"]);
+    let out = trt.ok(&["config", "list"]);
     let entries = parse_list(&out);
     assert_eq!(entries.len(), 5, "{out}");
 
@@ -106,8 +106,8 @@ fn fresh_install_reports_documented_defaults() {
     let (_, storage_path, is_default) = find(&entries, "storage.path");
     assert!(*is_default, "{out}");
     assert!(
-        storage_path.ends_with("/.config/trtodo"),
-        "expected an expanded ~/.config/trtodo path, got {storage_path}"
+        storage_path.ends_with("/.config/trt"),
+        "expected an expanded ~/.config/trt path, got {storage_path}"
     );
     assert_eq!(
         find(&entries, "default-category"),
@@ -127,12 +127,12 @@ fn fresh_install_reports_documented_defaults() {
 /// (holding a literal `null`) rather than absent.
 #[test]
 fn set_one_key_leaves_others_reporting_their_defaults() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    trtodo.ok(&["config", "set", "default-priority=high"]);
-    assert!(trtodo.config_path.exists());
+    trt.ok(&["config", "set", "default-priority=high"]);
+    assert!(trt.config_path.exists());
 
-    let out = trtodo.ok(&["config", "list"]);
+    let out = trt.ok(&["config", "list"]);
     let entries = parse_list(&out);
 
     // The key we set shows its value, without the `*`.
@@ -160,17 +160,17 @@ fn set_one_key_leaves_others_reporting_their_defaults() {
 /// `config default <key>` must restore the documented default, not `null`.
 #[test]
 fn config_default_restores_documented_default() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    trtodo.ok(&["config", "set", "default-priority=high"]);
-    let out = trtodo.ok(&["config", "list"]);
+    trt.ok(&["config", "set", "default-priority=high"]);
+    let out = trt.ok(&["config", "list"]);
     assert_eq!(
         find(&parse_list(&out), "default-priority"),
         &("default-priority".to_string(), "high".to_string(), false)
     );
 
-    trtodo.ok(&["config", "default", "default-priority"]);
-    let out = trtodo.ok(&["config", "list"]);
+    trt.ok(&["config", "default", "default-priority"]);
+    let out = trt.ok(&["config", "list"]);
     assert_eq!(
         find(&parse_list(&out), "default-priority"),
         &("default-priority".to_string(), "medium".to_string(), true)

--- a/tests/deleted_commands.rs
+++ b/tests/deleted_commands.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage of the `trtodo deleted` namespace - `list`,
+//! End-to-end coverage of the `trt deleted` namespace - `list`,
 //! `restore`, `flush` and its confirmation - plus the automatic purge
 //! driven by `deleted-task-lifespan`.
 //!
@@ -11,7 +11,7 @@
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, and
 //! that config points `storage.path` at the same `TempDir`, so the real
-//! `~/.config/trtodo` and the developer's actual todo data are never read or
+//! `~/.config/trt` and the developer's actual todo data are never read or
 //! written. This mirrors `tests/task_commands.rs`/`tests/category_commands.rs`'s
 //! harness exactly - see `home_guard` below, which is the load-bearing part:
 //! an earlier attempt was rejected specifically because its test suite wiped
@@ -22,15 +22,15 @@ use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-struct Trtodo {
+struct Trt {
     _dir: TempDir,
     config_path: std::path::PathBuf,
 }
 
-impl Trtodo {
+impl Trt {
     fn new() -> Self {
         let dir = TempDir::new().unwrap();
-        let config_path = dir.path().join("trtodo-config.json");
+        let config_path = dir.path().join("trt-config.json");
         let this = Self {
             config_path,
             _dir: dir,
@@ -47,34 +47,34 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trtodo"))
+        Command::new(env!("CARGO_BIN_EXE_trt"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.
             .env("HOME", self.home_guard())
             .args(args)
             .output()
-            .expect("failed to run trtodo")
+            .expect("failed to run trt")
     }
 
     /// A path that does not exist: if any code path tries to use `$HOME`
     /// instead of the configured storage location, the test fails loudly
     /// instead of touching the developer's real config/todo data.
     fn home_guard(&self) -> &Path {
-        Path::new("/nonexistent-trtodo-test-home")
+        Path::new("/nonexistent-trt-test-home")
     }
 
     /// The exact path `open_storage` would create task data under if it ever
     /// fell back to `$HOME` instead of the configured `storage.path`
-    /// (`main::open_storage`: `$HOME/.config/trtodo`). Asserting on this
+    /// (`main::open_storage`: `$HOME/.config/trt`). Asserting on this
     /// precise, app-owned subpath - rather than on `home_guard()` itself -
     /// is deliberate: some environments (e.g. a CI sandbox) may already have
     /// unrelated content sitting at the guard root for reasons outside this
     /// codebase's control, which would make "the guard root doesn't exist"
     /// a false failure. What actually matters, and what this proves, is
-    /// that trtodo itself never wrote anything there.
+    /// that trt itself never wrote anything there.
     fn app_home_marker(&self) -> std::path::PathBuf {
-        self.home_guard().join(".config").join("trtodo")
+        self.home_guard().join(".config").join("trt")
     }
 
     fn ok(&self, args: &[&str]) -> String {
@@ -105,76 +105,76 @@ impl Trtodo {
 
 #[test]
 fn flush_permanently_removes_a_deleted_task() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
     // Soft-deleted: already gone from `list`, but flush hasn't run yet.
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(!out.contains("Buy milk"), "{out}");
 
-    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
+    let out = trt.ok(&["deleted", "flush", "--yes"]);
     assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
 
     // A second flush finds nothing left to purge.
-    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
+    let out = trt.ok(&["deleted", "flush", "--yes"]);
     assert!(out.contains("Flushed 0 deleted task(s)"), "{out}");
 
-    // trtodo must never have created its own data under the guarded $HOME.
+    // trt must never have created its own data under the guarded $HOME.
     assert!(
-        !trtodo.app_home_marker().exists(),
+        !trt.app_home_marker().exists(),
         "flush must never touch the guarded $HOME path"
     );
 }
 
 #[test]
 fn flush_with_nothing_deleted_is_a_clean_no_op() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
     // Deliberately *without* `--yes`: with nothing at stake there is nothing
     // to confirm, so a flush of an empty deleted set stays a clean no-op
     // even with no terminal attached.
-    let out = trtodo.ok(&["deleted", "flush"]);
+    let out = trt.ok(&["deleted", "flush"]);
     assert!(out.contains("Flushed 0 deleted task(s)"), "{out}");
 
     // The live task is completely unaffected.
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy milk"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn flush_does_not_touch_live_tasks() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["add", "Walk dog", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["add", "Walk dog", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
-    trtodo.ok(&["deleted", "flush", "--yes"]);
+    trt.ok(&["deleted", "flush", "--yes"]);
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Walk dog"), "{out}");
     assert!(!out.contains("Buy milk"), "{out}");
 
     // The still-live task is still reachable and operable by name.
-    trtodo.ok(&["check", "Walk dog", "--category", "Work"]);
-    let out = trtodo.ok(&["list", "--completed"]);
+    trt.ok(&["check", "Walk dog", "--category", "Work"]);
+    let out = trt.ok(&["list", "--completed"]);
     assert!(out.contains("Walk dog"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn default_lifespan_of_zero_never_auto_purges() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
     // `deleted-task-lifespan` defaults to 0 ("never"); the deleted task's
     // `deleted_at` isn't backdated here (there's no CLI knob to fake the
@@ -184,25 +184,25 @@ fn default_lifespan_of_zero_never_auto_purges() {
     // purge logic itself (with a backdated `deleted_at`) is covered at the
     // storage/manager layer in src/storage/mod.rs and src/task_manager.rs,
     // since faking elapsed days end-to-end through the CLI isn't practical.
-    trtodo.ok(&["config", "list"]);
-    trtodo.ok(&["list"]);
-    trtodo.ok(&["category", "list"]);
+    trt.ok(&["config", "list"]);
+    trt.ok(&["list"]);
+    trt.ok(&["category", "list"]);
 
     // The task is still physically present in storage - if the automatic
     // sweep had wrongly purged it under the default threshold, this flush
     // would report 0 instead of 1.
-    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
+    let out = trt.ok(&["deleted", "flush", "--yes"]);
     assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn deleted_list_shows_id_title_category_and_deletion_date() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    let added = trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    let added = trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
     // The ID the task was given, so the listing can be checked to report the
     // real one rather than a position in a list.
@@ -213,7 +213,7 @@ fn deleted_list_shows_id_title_category_and_deletion_date() {
         .expect("add should report the new task's ID")
         .to_string();
 
-    let out = trtodo.ok(&["deleted", "list"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert!(out.contains("Deleted tasks:"), "{out}");
     assert!(out.contains(&format!("{id}: Buy milk")), "{out}");
     // The *real* category, by name - soft deletion keeps `category_id`
@@ -225,68 +225,68 @@ fn deleted_list_shows_id_title_category_and_deletion_date() {
     assert!(out.contains("deleted: 20"), "{out}");
 
     // Still hidden from the ordinary listing and search, as before.
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(!out.contains("Buy milk"), "{out}");
-    let out = trtodo.ok(&["list", "--search", "milk"]);
+    let out = trt.ok(&["list", "--search", "milk"]);
     assert!(!out.contains("Buy milk"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn deleted_list_says_so_explicitly_when_there_is_nothing_deleted() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
     // "A flush would destroy nothing" has to be said out loud: silence here
     // is indistinguishable from a command that failed to look.
-    let out = trtodo.ok(&["deleted", "list"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert!(out.contains("Deleted tasks:"), "{out}");
     assert!(out.contains("(none)"), "{out}");
     assert!(!out.contains("Buy milk"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn restore_returns_a_task_to_its_original_category() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
-    let out = trtodo.ok(&["deleted", "restore", "Buy milk"]);
+    let out = trt.ok(&["deleted", "restore", "Buy milk"]);
     assert!(out.contains("Task 'Buy milk' restored"), "{out}");
     assert!(out.contains("Work"), "{out}");
 
     // Back in the listing, in the category it was deleted from.
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy milk"), "{out}");
     assert!(out.contains("category: Work"), "{out}");
 
     // And out of the deleted set, so a later flush can't destroy it.
-    let out = trtodo.ok(&["deleted", "list"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert!(out.contains("(none)"), "{out}");
-    let out = trtodo.ok(&["deleted", "flush"]);
+    let out = trt.ok(&["deleted", "flush"]);
     assert!(out.contains("Flushed 0 deleted task(s)"), "{out}");
 
     // A restored task is an ordinary task again: operable by name, and
     // re-deletable.
-    trtodo.ok(&["check", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
-    let out = trtodo.ok(&["deleted", "list"]);
+    trt.ok(&["check", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert!(out.contains("Buy milk"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn restore_accepts_the_id_from_deleted_list() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    let added = trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    let added = trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
     let id = added
         .split("with ID ")
@@ -295,95 +295,95 @@ fn restore_accepts_the_id_from_deleted_list() {
         .expect("add should report the new task's ID")
         .to_string();
 
-    let out = trtodo.ok(&["deleted", "restore", &id]);
+    let out = trt.ok(&["deleted", "restore", &id]);
     assert!(out.contains("Task 'Buy milk' restored"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy milk"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn restore_refuses_a_live_task() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
     // Restore searches only soft-deleted tasks - the inverse of every other
     // task command's scope - so a perfectly good live task is "not found"
     // here rather than being silently touched.
-    let err = trtodo.err(&["deleted", "restore", "Buy milk"]);
+    let err = trt.err(&["deleted", "restore", "Buy milk"]);
     assert!(err.contains("no task matching 'Buy milk'"), "{err}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy milk"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn restore_of_an_ambiguous_title_fails_cleanly_with_no_terminal_attached() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Home"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Home"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Home"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Home"]);
 
     // Two deleted tasks share the title, and there is no terminal to ask
     // which one. The README's disambiguation rule turns into a typed error
     // instead of a hang - and the advice is to use an ID, which
     // `deleted list` prints.
-    let err = trtodo.err(&["deleted", "restore", "Buy milk"]);
+    let err = trt.err(&["deleted", "restore", "Buy milk"]);
     assert!(err.contains("no terminal is attached"), "{err}");
 
     // Neither task was restored, and both are still there to be rescued.
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(!out.contains("Buy milk"), "{out}");
-    let out = trtodo.ok(&["deleted", "list"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert_eq!(out.matches("Buy milk").count(), 2, "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn flush_refuses_to_destroy_anything_without_confirmation() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
     // Non-interactive (spawned with no terminal on stdin) and no `--yes`:
     // the deliberate choice is to refuse rather than destroy data
     // unattended, and to name the escape hatch in the error.
-    let err = trtodo.err(&["deleted", "flush"]);
+    let err = trt.err(&["deleted", "flush"]);
     assert!(err.contains("--yes"), "{err}");
     assert!(err.contains("deleted list"), "{err}");
 
     // Nothing was destroyed, so the task is still there to restore.
-    let out = trtodo.ok(&["deleted", "list"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert!(out.contains("Buy milk"), "{out}");
-    trtodo.ok(&["deleted", "restore", "Buy milk"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["deleted", "restore", "Buy milk"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy milk"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn flush_reports_which_tasks_it_removed() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["add", "Walk dog", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Walk dog", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["add", "Walk dog", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Walk dog", "--category", "Work"]);
 
     // A count alone leaves the user with no way to find out what they lost -
     // the rows are gone by the time they could look.
-    let out = trtodo.ok(&["deleted", "flush", "--yes"]);
+    let out = trt.ok(&["deleted", "flush", "--yes"]);
     assert!(
         out.contains("The following 2 task(s) will be permanently removed:"),
         "{out}"
@@ -394,59 +394,59 @@ fn flush_reports_which_tasks_it_removed() {
     assert!(out.contains("Flushed 2 deleted task(s)"), "{out}");
 
     // Gone for good: nothing left to list or restore.
-    let out = trtodo.ok(&["deleted", "list"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert!(out.contains("(none)"), "{out}");
-    let err = trtodo.err(&["deleted", "restore", "Buy milk"]);
+    let err = trt.err(&["deleted", "restore", "Buy milk"]);
     assert!(err.contains("no task matching 'Buy milk'"), "{err}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn flush_accepts_force_as_an_alias_for_yes() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
     // `--force` and `-y` are the conventional spellings of the same escape
     // hatch; scripts shouldn't have to guess which one this CLI chose.
-    let out = trtodo.ok(&["deleted", "flush", "--force"]);
+    let out = trt.ok(&["deleted", "flush", "--force"]);
     assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
 
-    trtodo.ok(&["add", "Walk dog", "--category", "Work"]);
-    trtodo.ok(&["delete", "Walk dog", "--category", "Work"]);
-    let out = trtodo.ok(&["deleted", "flush", "-y"]);
+    trt.ok(&["add", "Walk dog", "--category", "Work"]);
+    trt.ok(&["delete", "Walk dog", "--category", "Work"]);
+    let out = trt.ok(&["deleted", "flush", "-y"]);
     assert!(out.contains("Flushed 1 deleted task(s)"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }
 
 #[test]
 fn deleted_commands_survive_a_category_deletion() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
 
     // Deleting the category reassigns every task in it - soft-deleted ones
     // included - to Uncategorized, so the restore below is still well
     // defined and lands somewhere real.
-    trtodo.ok(&["category", "delete", "Work"]);
+    trt.ok(&["category", "delete", "Work"]);
 
-    let out = trtodo.ok(&["deleted", "list"]);
+    let out = trt.ok(&["deleted", "list"]);
     assert!(out.contains("Buy milk"), "{out}");
     assert!(out.contains("category: Uncategorized"), "{out}");
 
-    let out = trtodo.ok(&["deleted", "restore", "Buy milk"]);
+    let out = trt.ok(&["deleted", "restore", "Buy milk"]);
     assert!(out.contains("Uncategorized"), "{out}");
     // Not the "original category no longer exists" wording: as far as the
     // task is concerned Uncategorized *is* its category by this point.
     assert!(!out.contains("no longer exists"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy milk"), "{out}");
     assert!(out.contains("category: Uncategorized"), "{out}");
 
-    assert!(!trtodo.app_home_marker().exists());
+    assert!(!trt.app_home_marker().exists());
 }

--- a/tests/first_run.rs
+++ b/tests/first_run.rs
@@ -3,7 +3,7 @@
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, with
 //! `storage.path` pointing at that same `TempDir` and `$HOME` pointing at a
-//! path that does not exist, so the real `~/.config/trtodo` is never read or
+//! path that does not exist, so the real `~/.config/trt` is never read or
 //! written - which matters more here than anywhere else, since this is the
 //! one feature whose whole job is to write to a *fresh* install.
 //!
@@ -16,18 +16,18 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
-struct Trtodo {
+struct Trt {
     _dir: TempDir,
     config_path: PathBuf,
     data_dir: PathBuf,
 }
 
-impl Trtodo {
+impl Trt {
     /// A fresh install: a config file that only says where task data lives,
     /// and no task data of any kind yet.
     fn new() -> Self {
         let dir = TempDir::new().unwrap();
-        let config_path = dir.path().join("trtodo-config.json");
+        let config_path = dir.path().join("trt-config.json");
         let data_dir = dir.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
 
@@ -47,14 +47,14 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trtodo"))
+        Command::new(env!("CARGO_BIN_EXE_trt"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.
-            .env("HOME", Path::new("/nonexistent-trtodo-test-home"))
+            .env("HOME", Path::new("/nonexistent-trt-test-home"))
             .args(args)
             .output()
-            .expect("failed to run trtodo")
+            .expect("failed to run trt")
     }
 
     fn ok(&self, args: &[&str]) -> String {
@@ -72,7 +72,7 @@ impl Trtodo {
     /// the strongest available assertion that a command left task storage
     /// completely alone.
     fn data_file(&self) -> PathBuf {
-        self.data_dir.join("trtodo-data.json")
+        self.data_dir.join("trt-data.json")
     }
 
     /// Whether the first-run offer has been recorded as resolved. Read
@@ -105,34 +105,34 @@ impl Trtodo {
 /// on the duplicate-name check) or create anything more.
 #[test]
 fn accepting_creates_home_and_work_exactly_once() {
-    let trtodo = Trtodo::new();
-    assert!(!trtodo.offer_recorded());
+    let trt = Trt::new();
+    assert!(!trt.offer_recorded());
 
-    let out = trtodo.ok(&["--yes", "category", "list"]);
+    let out = trt.ok(&["--yes", "category", "list"]);
     assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
     assert!(out.contains("Category 'Work' added with ID 2"), "{out}");
-    assert!(trtodo.offer_recorded());
+    assert!(trt.offer_recorded());
 
     // Every subsequent run - with or without `--yes` - is a no-op.
-    let out = trtodo.ok(&["--yes", "category", "list"]);
+    let out = trt.ok(&["--yes", "category", "list"]);
     assert!(!out.contains("added with ID"), "{out}");
-    assert_eq!(trtodo.real_categories(), vec!["Home", "Work"]);
+    assert_eq!(trt.real_categories(), vec!["Home", "Work"]);
 }
 
 /// Declining creates neither category, and is a real answer: it is recorded,
 /// so no later run asks again - not even one that would have said yes.
 #[test]
 fn declining_creates_nothing_and_is_never_asked_again() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    let out = trtodo.ok(&["--no-input", "category", "list"]);
+    let out = trt.ok(&["--no-input", "category", "list"]);
     assert!(!out.contains("added with ID"), "{out}");
     assert!(out.contains("add categories yourself"), "{out}");
-    assert!(trtodo.offer_recorded());
+    assert!(trt.offer_recorded());
 
-    assert!(trtodo.real_categories().is_empty());
-    trtodo.ok(&["--yes", "list"]);
-    assert!(trtodo.real_categories().is_empty());
+    assert!(trt.real_categories().is_empty());
+    trt.ok(&["--yes", "list"]);
+    assert!(trt.real_categories().is_empty());
 }
 
 /// With no terminal attached and no flag saying what to assume, there is
@@ -146,39 +146,39 @@ fn declining_creates_nothing_and_is_never_asked_again() {
 /// the `--yes` run at the end stands in for.
 #[test]
 fn a_non_interactive_run_neither_blocks_nor_burns_the_offer() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert_eq!(out, "Tasks:\n", "{out}");
-    assert!(!trtodo.offer_recorded());
+    assert!(!trt.offer_recorded());
     assert!(
-        !trtodo.data_file().exists(),
+        !trt.data_file().exists(),
         "a first-run offer nobody could answer must not write task storage"
     );
 
-    let out = trtodo.ok(&["--yes", "category", "list"]);
+    let out = trt.ok(&["--yes", "category", "list"]);
     assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
 }
 
-/// `trtodo config ...` never opens task storage, so it must never make the
+/// `trt config ...` never opens task storage, so it must never make the
 /// offer either - creating categories from a read-only config query would
 /// write a data file (and its directory) as a side effect, and offering
 /// during `config set storage.path=...` would put the new categories in the
 /// location the user is in the middle of moving away from.
 #[test]
 fn config_commands_never_trigger_the_offer() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    trtodo.ok(&["config", "list"]);
-    trtodo.ok(&["--yes", "config", "list"]);
-    trtodo.ok(&["--yes", "config", "set", "default-priority=high"]);
+    trt.ok(&["config", "list"]);
+    trt.ok(&["--yes", "config", "list"]);
+    trt.ok(&["--yes", "config", "set", "default-priority=high"]);
 
-    assert!(!trtodo.offer_recorded());
-    assert!(!trtodo.data_file().exists());
+    assert!(!trt.offer_recorded());
+    assert!(!trt.data_file().exists());
 
     // The offer is not lost, just deferred to the first command that
     // actually touches task storage.
-    let out = trtodo.ok(&["--yes", "category", "list"]);
+    let out = trt.ok(&["--yes", "category", "list"]);
     assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
 }
 
@@ -188,43 +188,43 @@ fn config_commands_never_trigger_the_offer() {
 /// like a fresh install later on.
 #[test]
 fn existing_categories_mean_this_is_not_a_first_run() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
     // Created by a non-interactive run, so nothing has been offered or
     // recorded yet - only this one category exists.
-    trtodo.ok(&["category", "add", "Errands"]);
-    assert!(!trtodo.offer_recorded());
+    trt.ok(&["category", "add", "Errands"]);
+    assert!(!trt.offer_recorded());
 
-    let out = trtodo.ok(&["--yes", "category", "list"]);
+    let out = trt.ok(&["--yes", "category", "list"]);
     assert!(!out.contains("added with ID"), "{out}");
-    assert_eq!(trtodo.real_categories(), vec!["Errands"]);
-    assert!(trtodo.offer_recorded());
+    assert_eq!(trt.real_categories(), vec!["Errands"]);
+    assert!(trt.offer_recorded());
 }
 
 /// Deleting every category is a legitimate empty state, not a reinstall: the
 /// recorded marker means it is never mistaken for one.
 #[test]
 fn deleting_every_category_does_not_re_offer() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["--yes", "category", "list"]);
+    let trt = Trt::new();
+    trt.ok(&["--yes", "category", "list"]);
 
-    trtodo.ok(&["category", "delete", "Home"]);
-    trtodo.ok(&["category", "delete", "Work"]);
-    assert!(trtodo.real_categories().is_empty());
+    trt.ok(&["category", "delete", "Home"]);
+    trt.ok(&["category", "delete", "Work"]);
+    assert!(trt.real_categories().is_empty());
 
-    let out = trtodo.ok(&["--yes", "category", "list"]);
+    let out = trt.ok(&["--yes", "category", "list"]);
     assert!(!out.contains("added with ID"), "{out}");
-    assert!(trtodo.real_categories().is_empty());
+    assert!(trt.real_categories().is_empty());
 }
 
 /// The offer works the same way against the SQLite backend - it goes through
 /// `CategoryManager`, not any backend-specific path.
 #[test]
 fn the_offer_is_backend_agnostic() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+    let trt = Trt::new();
+    trt.ok(&["config", "set", "storage.type=sqlite"]);
 
-    let out = trtodo.ok(&["--yes", "category", "list"]);
+    let out = trt.ok(&["--yes", "category", "list"]);
     assert!(out.contains("Category 'Home' added with ID 1"), "{out}");
-    assert_eq!(trtodo.real_categories(), vec!["Home", "Work"]);
+    assert_eq!(trt.real_categories(), vec!["Home", "Work"]);
 }

--- a/tests/storage_backend_switch.rs
+++ b/tests/storage_backend_switch.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage of `trtodo config set storage.type=...`.
+//! End-to-end coverage of `trt config set storage.type=...`.
 //!
 //! Once the original "file is not a database" panic was gone, this was what
 //! remained: each backend keeps its own data file, so changing
@@ -13,22 +13,22 @@
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir` with
 //! `storage.path` pointing into the same `TempDir`, and `$HOME` at a path that
-//! does not exist, so the real `~/.config/trtodo` is never read or written.
+//! does not exist, so the real `~/.config/trt` is never read or written.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
-struct Trtodo {
+struct Trt {
     _dir: TempDir,
     config_path: PathBuf,
     data_dir: PathBuf,
 }
 
-impl Trtodo {
+impl Trt {
     fn new() -> Self {
         let dir = TempDir::new().unwrap();
-        let config_path = dir.path().join("trtodo-config.json");
+        let config_path = dir.path().join("trt-config.json");
         let data_dir = dir.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
 
@@ -46,14 +46,14 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trtodo"))
+        Command::new(env!("CARGO_BIN_EXE_trt"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.
-            .env("HOME", Path::new("/nonexistent-trtodo-test-home"))
+            .env("HOME", Path::new("/nonexistent-trt-test-home"))
             .args(args)
             .output()
-            .expect("failed to run trtodo")
+            .expect("failed to run trt")
     }
 
     fn ok(&self, args: &[&str]) -> String {
@@ -85,11 +85,11 @@ impl Trtodo {
     }
 
     fn json_file(&self) -> PathBuf {
-        self.data_dir.join("trtodo-data.json")
+        self.data_dir.join("trt-data.json")
     }
 
     fn sqlite_file(&self) -> PathBuf {
-        self.data_dir.join("trtodo-data.db")
+        self.data_dir.join("trt-data.db")
     }
 
     /// Seeds a category, a task in it, and a `category use` context - the
@@ -105,19 +105,19 @@ impl Trtodo {
 /// across instead of stranding it, and says so plainly.
 #[test]
 fn switching_backend_carries_existing_data_across() {
-    let trtodo = Trtodo::new();
-    trtodo.seed();
+    let trt = Trt::new();
+    trt.seed();
 
-    let json_before = std::fs::read_to_string(trtodo.json_file()).unwrap();
+    let json_before = std::fs::read_to_string(trt.json_file()).unwrap();
     assert!(json_before.contains("Finish report"));
 
-    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=sqlite"]);
+    let (stdout, stderr) = trt.ok_both(&["config", "set", "storage.type=sqlite"]);
     assert!(
         stdout.contains("Migrated 1 task(s) and 1 category from json to sqlite"),
         "expected an accurate migration report, got stdout: {stdout}"
     );
     assert!(
-        stdout.contains(&trtodo.json_file().display().to_string()),
+        stdout.contains(&trt.json_file().display().to_string()),
         "the user should be told exactly where their previous data still lives, got: {stdout}"
     );
     // The old "may require data migration" hedge is gone: a migration either
@@ -128,9 +128,9 @@ fn switching_backend_carries_existing_data_across() {
     );
 
     // The data is genuinely there under the new backend...
-    let categories = trtodo.ok(&["category", "list"]);
+    let categories = trt.ok(&["category", "list"]);
     assert!(categories.contains("Work"), "{categories}");
-    let tasks = trtodo.ok(&["list"]);
+    let tasks = trt.ok(&["list"]);
     assert!(tasks.contains("Finish report"), "{tasks}");
     // ... including the `category use` context.
     assert!(
@@ -141,11 +141,11 @@ fn switching_backend_carries_existing_data_across() {
     // ... and the switch was non-destructive: the JSON file is byte-for-byte
     // what it was.
     assert_eq!(
-        std::fs::read_to_string(trtodo.json_file()).unwrap(),
+        std::fs::read_to_string(trt.json_file()).unwrap(),
         json_before,
         "migrating must never rewrite or truncate the source store"
     );
-    assert!(trtodo.sqlite_file().exists());
+    assert!(trt.sqlite_file().exists());
 }
 
 /// Switching back to a backend that already holds data must refuse to
@@ -154,17 +154,17 @@ fn switching_backend_carries_existing_data_across() {
 /// a different feature with different risks.
 #[test]
 fn switching_back_to_a_populated_backend_refuses_to_clobber_and_says_so() {
-    let trtodo = Trtodo::new();
-    trtodo.seed();
-    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
+    let trt = Trt::new();
+    trt.seed();
+    trt.ok(&["config", "set", "storage.type=sqlite"]);
 
     // Diverge the two stores so a clobber in either direction is detectable.
-    trtodo.ok(&["add", "--category", "Work", "Only in sqlite"]);
+    trt.ok(&["add", "--category", "Work", "Only in sqlite"]);
 
-    let json_before = std::fs::read_to_string(trtodo.json_file()).unwrap();
-    let sqlite_before = std::fs::read(trtodo.sqlite_file()).unwrap();
+    let json_before = std::fs::read_to_string(trt.json_file()).unwrap();
+    let sqlite_before = std::fs::read(trt.sqlite_file()).unwrap();
 
-    let (_, stderr) = trtodo.ok_both(&["config", "set", "storage.type=json"]);
+    let (_, stderr) = trt.ok_both(&["config", "set", "storage.type=json"]);
     assert!(
         stderr.contains("json storage already holds"),
         "the user should be told why nothing was migrated, got: {stderr}"
@@ -174,26 +174,26 @@ fn switching_back_to_a_populated_backend_refuses_to_clobber_and_says_so() {
         "the user should be told their data is safe, got: {stderr}"
     );
     assert!(
-        stderr.contains(&trtodo.sqlite_file().display().to_string())
+        stderr.contains(&trt.sqlite_file().display().to_string())
             && stderr.contains("storage.type=sqlite"),
         "the user should be told where the other data is and how to reach it, got: {stderr}"
     );
 
     // Neither store was touched.
     assert_eq!(
-        std::fs::read_to_string(trtodo.json_file()).unwrap(),
+        std::fs::read_to_string(trt.json_file()).unwrap(),
         json_before
     );
-    assert_eq!(std::fs::read(trtodo.sqlite_file()).unwrap(), sqlite_before);
+    assert_eq!(std::fs::read(trt.sqlite_file()).unwrap(), sqlite_before);
 
     // The advertised escape hatch really works: the sqlite-only task is still
     // reachable by switching back.
-    let json_tasks = trtodo.ok(&["list"]);
+    let json_tasks = trt.ok(&["list"]);
     assert!(json_tasks.contains("Finish report"), "{json_tasks}");
     assert!(!json_tasks.contains("Only in sqlite"), "{json_tasks}");
 
-    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
-    let sqlite_tasks = trtodo.ok(&["list"]);
+    trt.ok(&["config", "set", "storage.type=sqlite"]);
+    let sqlite_tasks = trt.ok(&["list"]);
     assert!(sqlite_tasks.contains("Only in sqlite"), "{sqlite_tasks}");
 }
 
@@ -202,9 +202,9 @@ fn switching_back_to_a_populated_backend_refuses_to_clobber_and_says_so() {
 /// data at all.
 #[test]
 fn switching_with_nothing_stored_is_quiet() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=sqlite"]);
+    let (stdout, stderr) = trt.ok_both(&["config", "set", "storage.type=sqlite"]);
     assert_eq!(stdout, "Configuration updated successfully\n", "{stdout}");
     assert_eq!(
         stderr, "",
@@ -216,19 +216,19 @@ fn switching_with_nothing_stored_is_quiet() {
 /// so it must not report a migration (and must not risk writing anything).
 #[test]
 fn setting_storage_type_to_its_current_value_is_a_no_op() {
-    let trtodo = Trtodo::new();
-    trtodo.seed();
-    let json_before = std::fs::read_to_string(trtodo.json_file()).unwrap();
+    let trt = Trt::new();
+    trt.seed();
+    let json_before = std::fs::read_to_string(trt.json_file()).unwrap();
 
-    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=json"]);
+    let (stdout, stderr) = trt.ok_both(&["config", "set", "storage.type=json"]);
     assert_eq!(stdout, "Configuration updated successfully\n", "{stdout}");
     assert_eq!(stderr, "", "{stderr}");
     assert_eq!(
-        std::fs::read_to_string(trtodo.json_file()).unwrap(),
+        std::fs::read_to_string(trt.json_file()).unwrap(),
         json_before
     );
     assert!(
-        !trtodo.sqlite_file().exists(),
+        !trt.sqlite_file().exists(),
         "a no-op switch must not materialise the other backend's file"
     );
 }
@@ -238,19 +238,19 @@ fn setting_storage_type_to_its_current_value_is_a_no_op() {
 /// half-created store behind.
 #[test]
 fn an_unknown_storage_type_is_still_rejected_cleanly() {
-    let trtodo = Trtodo::new();
-    trtodo.seed();
+    let trt = Trt::new();
+    trt.seed();
 
-    let output = trtodo.run(&["config", "set", "storage.type=postgres"]);
+    let output = trt.run(&["config", "set", "storage.type=postgres"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
         stderr.contains("storage.type must be one of"),
         "expected the config validation error, got: {stderr}"
     );
-    assert!(!trtodo.sqlite_file().exists());
+    assert!(!trt.sqlite_file().exists());
     // The setting is unchanged, so the user is still looking at their data.
-    assert!(trtodo.ok(&["list"]).contains("Finish report"));
+    assert!(trt.ok(&["list"]).contains("Finish report"));
 }
 
 /// A store that can't be read is exactly when a user most wants to switch away
@@ -260,14 +260,14 @@ fn an_unknown_storage_type_is_still_rejected_cleanly() {
 /// that nothing was migrated and that the file was left alone.
 #[test]
 fn an_unreadable_source_store_warns_but_does_not_block_the_switch() {
-    let trtodo = Trtodo::new();
-    trtodo.seed();
+    let trt = Trt::new();
+    trt.seed();
 
     // Corrupt the JSON store behind the app's back.
-    std::fs::write(trtodo.json_file(), "{ this is not valid json").unwrap();
-    let corrupted = std::fs::read_to_string(trtodo.json_file()).unwrap();
+    std::fs::write(trt.json_file(), "{ this is not valid json").unwrap();
+    let corrupted = std::fs::read_to_string(trt.json_file()).unwrap();
 
-    let (stdout, stderr) = trtodo.ok_both(&["config", "set", "storage.type=sqlite"]);
+    let (stdout, stderr) = trt.ok_both(&["config", "set", "storage.type=sqlite"]);
     assert!(
         stdout.contains("Configuration updated successfully"),
         "the switch itself must still succeed, got: {stdout}"
@@ -280,12 +280,9 @@ fn an_unreadable_source_store_warns_but_does_not_block_the_switch() {
 
     // The unreadable file is left exactly as found - it is the only copy of
     // whatever is salvageable in there.
-    assert_eq!(
-        std::fs::read_to_string(trtodo.json_file()).unwrap(),
-        corrupted
-    );
+    assert_eq!(std::fs::read_to_string(trt.json_file()).unwrap(), corrupted);
 
     // And the new backend is usable, so the user isn't stuck.
-    trtodo.ok(&["category", "add", "Fresh"]);
-    assert!(trtodo.ok(&["category", "list"]).contains("Fresh"));
+    trt.ok(&["category", "add", "Fresh"]);
+    assert!(trt.ok(&["category", "list"]).contains("Fresh"));
 }

--- a/tests/task_commands.rs
+++ b/tests/task_commands.rs
@@ -1,23 +1,23 @@
-//! End-to-end coverage of `trtodo add/delete/update/check/uncheck/move/list`.
+//! End-to-end coverage of `trt add/delete/update/check/uncheck/move/list`.
 //!
 //! Every invocation is pointed at a `--config` file inside a `TempDir`, and
 //! that config points `storage.path` at the same `TempDir`, so the real
-//! `~/.config/trtodo` and the developer's actual todo data are never read or
+//! `~/.config/trt` and the developer's actual todo data are never read or
 //! written. This mirrors `tests/category_commands.rs`'s harness exactly.
 
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-struct Trtodo {
+struct Trt {
     _dir: TempDir,
     config_path: std::path::PathBuf,
 }
 
-impl Trtodo {
+impl Trt {
     fn new() -> Self {
         let dir = TempDir::new().unwrap();
-        let config_path = dir.path().join("trtodo-config.json");
+        let config_path = dir.path().join("trt-config.json");
         let this = Self {
             config_path,
             _dir: dir,
@@ -34,21 +34,21 @@ impl Trtodo {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(env!("CARGO_BIN_EXE_trtodo"))
+        Command::new(env!("CARGO_BIN_EXE_trt"))
             .arg("--config")
             .arg(&self.config_path)
             // Make sure nothing can silently fall back to a real home directory.
             .env("HOME", self.home_guard())
             .args(args)
             .output()
-            .expect("failed to run trtodo")
+            .expect("failed to run trt")
     }
 
     /// A path that does not exist: if any code path tries to use `$HOME`
     /// instead of the configured storage location, the test fails loudly
     /// instead of touching the developer's real config/todo data.
     fn home_guard(&self) -> &Path {
-        Path::new("/nonexistent-trtodo-test-home")
+        Path::new("/nonexistent-trt-test-home")
     }
 
     fn ok(&self, args: &[&str]) -> String {
@@ -75,22 +75,22 @@ impl Trtodo {
 
 #[test]
 fn add_defaults_priority_from_config_and_lists_it() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
 
     // No --priority: falls back to the configured/documented default
     // (medium), not a hardcoded value.
-    let out = trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["add", "Buy milk", "--category", "Work"]);
     assert!(out.contains("added with ID 1"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(
         out.contains("1: [ ] Buy milk (priority: medium, category: Work)"),
         "{out}"
     );
 
     // Explicit --priority overrides the default.
-    trtodo.ok(&[
+    trt.ok(&[
         "add",
         "Walk dog",
         "--category",
@@ -98,7 +98,7 @@ fn add_defaults_priority_from_config_and_lists_it() {
         "--priority",
         "high",
     ]);
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(
         out.contains("2: [ ] Walk dog (priority: high, category: Work)"),
         "{out}"
@@ -106,9 +106,9 @@ fn add_defaults_priority_from_config_and_lists_it() {
 
     // Changing the configured default changes what a subsequent bare `add`
     // picks up.
-    trtodo.ok(&["config", "set", "default-priority=low"]);
-    trtodo.ok(&["add", "Water plants", "--category", "Work"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["config", "set", "default-priority=low"]);
+    trt.ok(&["add", "Water plants", "--category", "Work"]);
+    let out = trt.ok(&["list"]);
     assert!(
         out.contains("3: [ ] Water plants (priority: low, category: Work)"),
         "{out}"
@@ -119,46 +119,46 @@ fn add_defaults_priority_from_config_and_lists_it() {
 /// tried in order, most specific first.
 #[test]
 fn add_resolves_its_category_in_precedence_order() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["category", "add", "Errands"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["category", "add", "Errands"]);
 
     // Step 4: nothing set at all - no --category, no context, no
     // default-category - so the task is simply uncategorized rather than an
     // error.
-    let out = trtodo.ok(&["add", "Loose task"]);
+    let out = trt.ok(&["add", "Loose task"]);
     assert!(out.contains("in category 'Uncategorized'"), "{out}");
 
     // Step 3: `default-category` now supplies it. This is the step that did
     // not exist before - the setting was stored, validated and listed, but
     // never read by anything.
-    trtodo.ok(&["config", "set", "default-category=Errands"]);
-    let out = trtodo.ok(&["add", "Configured task"]);
+    trt.ok(&["config", "set", "default-category=Errands"]);
+    let out = trt.ok(&["add", "Configured task"]);
     assert!(out.contains("in category 'Errands'"), "{out}");
 
     // Step 2: an explicit `category use` context outranks the configured
     // default - transient intent beats persistent configuration.
-    trtodo.ok(&["category", "use", "Home"]);
-    let out = trtodo.ok(&["add", "Context task"]);
+    trt.ok(&["category", "use", "Home"]);
+    let out = trt.ok(&["add", "Context task"]);
     assert!(out.contains("in category 'Home'"), "{out}");
 
     // Step 1: an explicit --category outranks both.
-    let out = trtodo.ok(&["add", "Explicit task", "--category", "Work"]);
+    let out = trt.ok(&["add", "Explicit task", "--category", "Work"]);
     assert!(out.contains("in category 'Work'"), "{out}");
 
     // Clearing the context falls back to the configured default again, rather
     // than to Uncategorized - the two settings do not consume each other.
-    trtodo.ok(&["category", "clear"]);
-    let out = trtodo.ok(&["add", "Back to default"]);
+    trt.ok(&["category", "clear"]);
+    let out = trt.ok(&["add", "Back to default"]);
     assert!(out.contains("in category 'Errands'"), "{out}");
 
     // And unsetting the default falls the rest of the way to Uncategorized.
-    trtodo.ok(&["config", "default", "default-category"]);
-    let out = trtodo.ok(&["add", "Truly loose"]);
+    trt.ok(&["config", "default", "default-category"]);
+    let out = trt.ok(&["add", "Truly loose"]);
     assert!(out.contains("in category 'Uncategorized'"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(
         out.contains("Loose task (priority: medium, category: Uncategorized)"),
         "{out}"
@@ -183,11 +183,11 @@ fn add_resolves_its_category_in_precedence_order() {
 /// than quietly filing the task under Uncategorized.
 #[test]
 fn add_errors_when_the_configured_default_category_does_not_resolve() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
     // A name that never existed - `config set` accepts it happily.
-    trtodo.ok(&["config", "set", "default-category=Ghost"]);
-    let err = trtodo.fail(&["add", "Orphaned task"]);
+    trt.ok(&["config", "set", "default-category=Ghost"]);
+    let err = trt.fail(&["add", "Orphaned task"]);
     assert!(err.contains("default-category"), "{err}");
     assert!(err.contains("Ghost"), "{err}");
     // The message has to be actionable, since the user cannot see which of the
@@ -195,29 +195,29 @@ fn add_errors_when_the_configured_default_category_does_not_resolve() {
     assert!(err.contains("--category"), "{err}");
 
     // Nothing was written: refusing must not half-succeed.
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(!out.contains("Orphaned task"), "{out}");
 
     // A broken default only breaks the `add`s that actually fall through to
     // it - an explicit --category still works.
-    trtodo.ok(&["category", "add", "Work"]);
-    let out = trtodo.ok(&["add", "Explicit task", "--category", "Work"]);
+    trt.ok(&["category", "add", "Work"]);
+    let out = trt.ok(&["add", "Explicit task", "--category", "Work"]);
     assert!(out.contains("in category 'Work'"), "{out}");
 
     // ...as does a `category use` context, which is resolved one step earlier.
-    trtodo.ok(&["category", "use", "Work"]);
-    let out = trtodo.ok(&["add", "Context task"]);
+    trt.ok(&["category", "use", "Work"]);
+    let out = trt.ok(&["add", "Context task"]);
     assert!(out.contains("in category 'Work'"), "{out}");
 
     // A default that was valid when set but whose category has since been
     // deleted behaves the same way - which is why validating at `config set`
     // time would not have been enough.
-    trtodo.ok(&["category", "clear"]);
-    trtodo.ok(&["category", "add", "Temporary"]);
-    trtodo.ok(&["config", "set", "default-category=Temporary"]);
-    trtodo.ok(&["add", "Fine for now"]);
-    trtodo.ok(&["category", "delete", "Temporary"]);
-    let err = trtodo.fail(&["add", "Too late"]);
+    trt.ok(&["category", "clear"]);
+    trt.ok(&["category", "add", "Temporary"]);
+    trt.ok(&["config", "set", "default-category=Temporary"]);
+    trt.ok(&["add", "Fine for now"]);
+    trt.ok(&["category", "delete", "Temporary"]);
+    let err = trt.fail(&["add", "Too late"]);
     assert!(err.contains("Temporary"), "{err}");
 }
 
@@ -225,33 +225,33 @@ fn add_errors_when_the_configured_default_category_does_not_resolve() {
 /// goes through the same resolution as `--category`.
 #[test]
 fn add_accepts_a_default_category_given_as_an_id() {
-    let trtodo = Trtodo::new();
-    let out = trtodo.ok(&["category", "add", "Work"]);
+    let trt = Trt::new();
+    let out = trt.ok(&["category", "add", "Work"]);
     assert!(out.contains("added with ID 1"), "{out}");
 
-    trtodo.ok(&["config", "set", "default-category=1"]);
-    let out = trtodo.ok(&["add", "By ID"]);
+    trt.ok(&["config", "set", "default-category=1"]);
+    let out = trt.ok(&["add", "By ID"]);
     assert!(out.contains("in category 'Work'"), "{out}");
 }
 
 #[test]
 fn add_can_target_the_uncategorized_category_by_name_or_id() {
-    let trtodo = Trtodo::new();
+    let trt = Trt::new();
 
-    trtodo.ok(&["add", "Loose task", "--category", "Uncategorized"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["add", "Loose task", "--category", "Uncategorized"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("category: Uncategorized"), "{out}");
 
-    trtodo.ok(&["add", "Another loose task", "--category", "0"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["add", "Another loose task", "--category", "0"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Another loose task"), "{out}");
 }
 
 #[test]
 fn list_filters_by_search_completed_and_priority() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&[
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&[
         "add",
         "Buy milk",
         "--category",
@@ -259,7 +259,7 @@ fn list_filters_by_search_completed_and_priority() {
         "--priority",
         "high",
     ]);
-    trtodo.ok(&[
+    trt.ok(&[
         "add",
         "Buy bread",
         "--category",
@@ -267,41 +267,41 @@ fn list_filters_by_search_completed_and_priority() {
         "--priority",
         "low",
     ]);
-    trtodo.ok(&["check", "Buy milk", "--category", "Work"]);
+    trt.ok(&["check", "Buy milk", "--category", "Work"]);
 
-    let out = trtodo.ok(&["list", "--search", "bread"]);
+    let out = trt.ok(&["list", "--search", "bread"]);
     assert!(out.contains("Buy bread"), "{out}");
     assert!(!out.contains("Buy milk"), "{out}");
 
-    let out = trtodo.ok(&["list", "--completed"]);
+    let out = trt.ok(&["list", "--completed"]);
     assert!(out.contains("Buy milk"), "{out}");
     assert!(!out.contains("Buy bread"), "{out}");
 
-    let out = trtodo.ok(&["list", "--priority", "low"]);
+    let out = trt.ok(&["list", "--priority", "low"]);
     assert!(out.contains("Buy bread"), "{out}");
     assert!(!out.contains("Buy milk"), "{out}");
 }
 
 #[test]
 fn check_and_uncheck_by_explicit_category_and_by_context() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
     // Explicit --category.
-    trtodo.ok(&["check", "Buy milk", "--category", "Work"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["check", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("[x] Buy milk"), "{out}");
 
-    trtodo.ok(&["uncheck", "Buy milk", "--category", "Work"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["uncheck", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("[ ] Buy milk"), "{out}");
 
     // Falls back to the current category context when --category is
     // omitted (README).
-    trtodo.ok(&["category", "use", "Work"]);
-    trtodo.ok(&["check", "Buy milk"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["category", "use", "Work"]);
+    trt.ok(&["check", "Buy milk"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("[x] Buy milk"), "{out}");
 
     // Without --category and without a context, resolution now searches
@@ -309,133 +309,133 @@ fn check_and_uncheck_by_explicit_category_and_by_context() {
     // instead of erroring - and since "Buy milk" is unambiguous here (it
     // only exists in Work), that succeeds cleanly rather than requiring a
     // context.
-    trtodo.ok(&["category", "clear"]);
-    let out = trtodo.ok(&["check", "Buy milk"]);
+    trt.ok(&["category", "clear"]);
+    let out = trt.ok(&["check", "Buy milk"]);
     assert!(out.contains("checked off"), "{out}");
 }
 
 #[test]
 fn check_all_and_uncheck_all_require_and_use_the_category_context() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["add", "Work task", "--category", "Work"]);
-    trtodo.ok(&["add", "Home task", "--category", "Home"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["add", "Work task", "--category", "Work"]);
+    trt.ok(&["add", "Home task", "--category", "Home"]);
 
     // No context set: check-all/uncheck-all have no --category argument at
     // all, so this must fail cleanly rather than guess.
-    let err = trtodo.fail(&["check-all"]);
+    let err = trt.fail(&["check-all"]);
     assert!(err.contains("no category context"), "{err}");
     // The advice must be actionable: `check-all` accepts no --category, so
     // the message must not tell the user to pass one (it used to).
     assert!(err.contains("category use"), "{err}");
     assert!(!err.contains("--category"), "{err}");
 
-    trtodo.ok(&["category", "use", "Work"]);
-    let out = trtodo.ok(&["check-all"]);
+    trt.ok(&["category", "use", "Work"]);
+    let out = trt.ok(&["check-all"]);
     assert!(out.contains("Checked off 1 task(s)"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("[x] Work task"), "{out}");
     assert!(out.contains("[ ] Home task"), "{out}");
 
-    let out = trtodo.ok(&["uncheck-all"]);
+    let out = trt.ok(&["uncheck-all"]);
     assert!(out.contains("Unchecked 1 task(s)"), "{out}");
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("[ ] Work task"), "{out}");
 }
 
 #[test]
 fn move_simple_syntax_uses_category_context() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
     // No context: the simple syntax has no --category at all, so it needs
     // an explicit context first.
-    let err = trtodo.fail(&["move", "Buy milk", "--to", "Home"]);
+    let err = trt.fail(&["move", "Buy milk", "--to", "Home"]);
     assert!(err.contains("no category context"), "{err}");
     // `move` has no --category either, but it does have an escape hatch the
     // message should point at: the extended --from/--task form.
     assert!(!err.contains("--category"), "{err}");
     assert!(err.contains("--from"), "{err}");
 
-    trtodo.ok(&["category", "use", "Work"]);
-    let out = trtodo.ok(&["move", "Buy milk", "--to", "Home"]);
+    trt.ok(&["category", "use", "Work"]);
+    let out = trt.ok(&["move", "Buy milk", "--to", "Home"]);
     assert!(out.contains("moved to 'Home'"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("category: Home"), "{out}");
 }
 
 #[test]
 fn move_extended_syntax_and_omitted_to_goes_to_uncategorized() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
     // Extended syntax with an explicit --to.
-    let out = trtodo.ok(&[
+    let out = trt.ok(&[
         "move", "--from", "Work", "--to", "Home", "--task", "Buy milk",
     ]);
     assert!(out.contains("moved to 'Home'"), "{out}");
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("category: Home"), "{out}");
 
     // Omitting --to moves the task to Uncategorized (README).
-    let out = trtodo.ok(&["move", "--from", "Home", "--task", "Buy milk"]);
+    let out = trt.ok(&["move", "--from", "Home", "--task", "Buy milk"]);
     assert!(out.contains("moved to 'Uncategorized'"), "{out}");
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("category: Uncategorized"), "{out}");
 }
 
 #[test]
 fn move_rejects_incoherent_argument_combinations() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
     // Neither syntax: no task reference at all.
-    let err = trtodo.fail(&["move", "--to", "Work"]);
+    let err = trt.fail(&["move", "--to", "Work"]);
     assert!(err.contains("invalid 'move' arguments"), "{err}");
 
     // --task without the required --from.
-    let err = trtodo.fail(&["move", "--task", "Buy milk", "--to", "Work"]);
+    let err = trt.fail(&["move", "--task", "Buy milk", "--to", "Work"]);
     assert!(err.contains("invalid 'move' arguments"), "{err}");
 
     // Simple syntax missing its required --to.
-    let err = trtodo.fail(&["move", "Buy milk"]);
+    let err = trt.fail(&["move", "Buy milk"]);
     assert!(err.contains("invalid 'move' arguments"), "{err}");
 }
 
 #[test]
 fn delete_is_soft_and_the_task_disappears_from_list() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    trtodo.ok(&["add", "Walk dog", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    trt.ok(&["add", "Walk dog", "--category", "Work"]);
 
-    let out = trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["delete", "Buy milk", "--category", "Work"]);
     assert!(out.contains("deleted"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(!out.contains("Buy milk"), "{out}");
     assert!(out.contains("Walk dog"), "{out}");
 
     // Deleting an already-nonexistent task is a clean error, not a panic.
-    let err = trtodo.fail(&["delete", "Buy milk", "--category", "Work"]);
+    let err = trt.fail(&["delete", "Buy milk", "--category", "Work"]);
     assert!(err.starts_with("error: "), "{err}");
 }
 
 #[test]
 fn update_renames_a_task() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
 
-    let out = trtodo.ok(&[
+    let out = trt.ok(&[
         "update",
         "Buy milk",
         "--to",
@@ -445,23 +445,23 @@ fn update_renames_a_task() {
     ]);
     assert!(out.contains("renamed to 'Buy oat milk'"), "{out}");
 
-    let out = trtodo.ok(&["list"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy oat milk"), "{out}");
     assert!(!out.contains("Buy milk\n"), "{out}");
 }
 
 #[test]
 fn same_task_name_in_different_categories_is_disambiguated_by_category() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["add", "Call mom", "--category", "Work"]);
-    trtodo.ok(&["add", "Call mom", "--category", "Home"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["add", "Call mom", "--category", "Work"]);
+    trt.ok(&["add", "Call mom", "--category", "Home"]);
 
     // Scoping to one category resolves cleanly - no prompt needed since
     // --category already disambiguates cross-category duplicates.
-    trtodo.ok(&["check", "Call mom", "--category", "Work"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["check", "Call mom", "--category", "Work"]);
+    let out = trt.ok(&["list"]);
     // Exactly one "Call mom" line is checked, the other is not.
     let checked_lines: Vec<&str> = out
         .lines()
@@ -472,30 +472,30 @@ fn same_task_name_in_different_categories_is_disambiguated_by_category() {
 
 #[test]
 fn same_task_name_in_one_category_without_a_terminal_is_a_clean_error() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["add", "Duplicate", "--category", "Work"]);
-    trtodo.ok(&["add", "Duplicate", "--category", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["add", "Duplicate", "--category", "Work"]);
+    trt.ok(&["add", "Duplicate", "--category", "Work"]);
 
     // Two tasks share both name *and* category: `--category` cannot
     // disambiguate between them, and the test harness has no real
     // terminal attached, so this must fail cleanly (README's prompt,
     // detected as non-interactive) instead of hanging or panicking.
-    let err = trtodo.fail(&["check", "Duplicate", "--category", "Work"]);
+    let err = trt.fail(&["check", "Duplicate", "--category", "Work"]);
     assert!(err.contains("no terminal is attached"), "{err}");
 
     // The task ID still works to disambiguate directly.
-    let out = trtodo.ok(&["check", "2", "--category", "Work"]);
+    let out = trt.ok(&["check", "2", "--category", "Work"]);
     assert!(out.contains("checked off"), "{out}");
 }
 
 #[test]
 fn same_task_name_across_categories_with_no_context_reaches_the_disambiguation_prompt() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["category", "add", "Work"]);
-    trtodo.ok(&["category", "add", "Home"]);
-    trtodo.ok(&["add", "Call mom", "--category", "Work"]);
-    trtodo.ok(&["add", "Call mom", "--category", "Home"]);
+    let trt = Trt::new();
+    trt.ok(&["category", "add", "Work"]);
+    trt.ok(&["category", "add", "Home"]);
+    trt.ok(&["add", "Call mom", "--category", "Work"]);
+    trt.ok(&["add", "Call mom", "--category", "Home"]);
 
     // No --category and no context set: resolution is unscoped across every
     // category, so the two same-named tasks in different categories collide
@@ -503,35 +503,35 @@ fn same_task_name_across_categories_with_no_context_reaches_the_disambiguation_p
     // unreachable because these commands always required a category scope.
     // The test harness has no real terminal attached, so the prompt
     // surfaces as a clean `PromptError::NotInteractive`, not `NoCategoryContext`.
-    let err = trtodo.fail(&["check", "Call mom"]);
+    let err = trt.fail(&["check", "Call mom"]);
     assert!(err.contains("no terminal is attached"), "{err}");
 
-    let err = trtodo.fail(&["delete", "Call mom"]);
+    let err = trt.fail(&["delete", "Call mom"]);
     assert!(err.contains("no terminal is attached"), "{err}");
 
-    let err = trtodo.fail(&["update", "Call mom", "--to", "Call dad"]);
+    let err = trt.fail(&["update", "Call mom", "--to", "Call dad"]);
     assert!(err.contains("no terminal is attached"), "{err}");
 
     // The task ID still disambiguates directly, with no category needed.
-    let out = trtodo.ok(&["check", "1"]);
+    let out = trt.ok(&["check", "1"]);
     assert!(out.contains("checked off"), "{out}");
 }
 
 #[test]
 fn task_lifecycle_end_to_end_with_sqlite_backend() {
-    let trtodo = Trtodo::new();
-    trtodo.ok(&["config", "set", "storage.type=sqlite"]);
-    trtodo.ok(&["category", "add", "Work"]);
+    let trt = Trt::new();
+    trt.ok(&["config", "set", "storage.type=sqlite"]);
+    trt.ok(&["category", "add", "Work"]);
 
-    trtodo.ok(&["add", "Buy milk", "--category", "Work"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["add", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["list"]);
     assert!(out.contains("Buy milk"), "{out}");
 
-    trtodo.ok(&["check", "Buy milk", "--category", "Work"]);
-    let out = trtodo.ok(&["list", "--completed"]);
+    trt.ok(&["check", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["list", "--completed"]);
     assert!(out.contains("Buy milk"), "{out}");
 
-    trtodo.ok(&["delete", "Buy milk", "--category", "Work"]);
-    let out = trtodo.ok(&["list"]);
+    trt.ok(&["delete", "Buy milk", "--category", "Work"]);
+    let out = trt.ok(&["list"]);
     assert!(!out.contains("Buy milk"), "{out}");
 }


### PR DESCRIPTION
Closes #45, closes #46, closes #47, closes #48.

Clears every item in the roadmap's release-engineering block except #44 itself, and renames the binary while there is still no release to be compatible with.

## The rename

**BREAKING CHANGE.** The binary is `trt`, not `trtodo`. Configuration and data move from `~/.config/trtodo/` to `~/.config/trt/`, the files become `trt-config.json` / `trt-data.json` / `trt-data.db`, and the environment variable is `TRT_CONFIG`.

Six characters is a lot for something run several times a day. The on-disk identity moved too, not just the command — a `trt` binary writing to a `trtodo` directory reads as a leftover rather than a decision, and the README documents those paths as specification.

Timed deliberately: no release exists, so no installed copy has data this could orphan. The same change after #44 ships would need a migration path.

`tr` was the shorter candidate and was rejected — it is POSIX-specified and ships in coreutils, so shadowing it would break shell scripts anywhere this sorted earlier on `PATH`, in ways that surface far from the cause. `trt` is the shortest name that collides with nothing on `PATH`.

## Release engineering

| Issue | What landed |
| --- | --- |
| #47 | `tempfile` dropped from `[dependencies]`. All seven uses are behind `#[cfg(test)]`; the `[dev-dependencies]` entry was already carrying it. |
| #48 | CI derives per-binary and total test counts into the job summary. The hand-maintained number is gone from `docs/WORKING-NOTES.md`, and #20's stale copy is corrected. |
| #46 | `test` becomes a matrix across Linux, macOS, and Windows. `fmt`/`clippy` split into a job that runs once. `actions/checkout@v4` everywhere. Dependabot enabled — monthly, grouped, majors separate. |
| #45 | Package metadata, `license = "GPL-3.0-only"` matching the tree, `rust-version = "1.78"`, and a CI job that runs the suite on that floor. |

Three decisions embedded in these, each a small revert if you disagree:

- **`license = "GPL-3.0-only"`, not `-or-later`.** The `LICENSE` file carries the bare GPL-3.0 text without the "or any later version" grant, and that permission has to be given explicitly rather than assumed.
- **Left publishable rather than `publish = false`.** `publish = false` also blocks `cargo publish --dry-run`, so the manifest would rot unpublishable with nothing reporting it. The dry run now runs in CI instead.
- **Dependabot enabled rather than declined.** #46 asked for the question to be closed either way.

`authors` is deliberately absent despite #45 listing it — it is the one field that would put a personal email in a public manifest, which is yours to add.

## Two findings worth not re-deriving

**The MSRV floor is 1.78 because of the lockfile, not the dependencies.** The highest floor any dependency declares is clap's 1.70, and it is unreachable: the committed `Cargo.lock` is lockfile v4, which no Cargo before 1.78 can parse. On 1.70 the build fails before touching a single dependency. Lowering the floor means regenerating the lockfile in the older format — a deliberate choice, not a free one. 1.78 was verified by running the whole suite against it, not inferred.

**`trt` is taken on crates.io** by an unrelated tokio runtime library, so the package name and binary name still cannot be made to match. That crate ships no executable, so the clash is over the crates.io namespace only — `cargo install trusty_rusty_todo_list` still yields a working `trt`.

## Verification

Run locally against the full tree: `cargo fmt --all -- --check` clean, `cargo clippy -- -D warnings` clean, 173 tests across 7 binaries on stable, 173 on the 1.78 floor, `cargo publish --dry-run` packages and verifies.

End-to-end against a scratch `$HOME`, confirming the on-disk rename rather than trusting the diff:

```
~/.config/trt/trt-config.json
~/.config/trt/trt-data.json
```

**What is not verified:** the macOS and Windows legs have never run — that is the entire point of #46, and this PR is the first thing that can execute them. The rename touched path handling in `config.rs`, which is where a platform difference would surface. Expect follow-up commits here; #46 is explicit that a platform-specific failure gets fixed rather than excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyoC58k1sv3ia8jEDen2ig

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyoC58k1sv3ia8jEDen2ig)_