### PR TITLE
fix(config): use the platform config directory on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # trusty_rusty_todo_list
 
 A CLI todo list in Rust. Binary name is `trt`. Tasks belong to categories;
-configuration and data live under `~/.config/trt` by default.
+configuration and data live under the platform's configuration directory by
+default: `~/.config/trt` on Linux and macOS, `%APPDATA%\trt` on Windows.
 
 `README.md` is the specification, not just documentation. Where behavior and
 README disagree, that is a bug in one of them — decide which, and fix that one.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The binary named `trt` will accept various arguments
 
 ## Additional Behaviors
 
-The first time `trt` is run it should offer to create the default categories of "Home" and "Work" and create a configuration file under `.config\trt\` or `C:\\Users\\<username>\\AppData\\Roaming\trt`.
+The first time `trt` is run it should offer to create the default categories of "Home" and "Work" and create a configuration file in the platform's configuration directory: `~/.config/trt` on Linux and macOS, `C:\Users\<username>\AppData\Roaming\trt` on Windows.
 
 That offer defaults to yes (a bare Enter accepts it) and is made at most once:
 
@@ -89,7 +89,7 @@ The keys below are the configurable ones - they are exactly what `config set`, `
 | ----------------------- | ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `deleted-task-lifespan` | `0`                | integer<1..?>       | Number of days before task in Deleted category are deleted. A value of 0, the default, indicates they are never automatically deleted |
 | `storage.type`          | `json`             | `json\|sqlite`      | Type of storage backend to use                                                                                                        |
-| `storage.path`          | `~/.config/trt` | string              | Path to storage location                                                                                                              |
+| `storage.path`          | `~/.config/trt` (`%APPDATA%\trt` on Windows) | string              | Path to storage location - the configuration directory named above                                                                     |
 | `default-category`      | `null`             | string              | Category `add` files new tasks into when no `--category` is given and no category context is set. Must name an existing category (by name or ID) - `add` reports an error rather than guessing if it no longer resolves. `category update` carries this setting along when it renames the category it currently names |
 | `default-priority`      | `medium`           | `high\|medium\|low` | Default priority for new tasks                                                                                                        |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -243,17 +243,60 @@ fn default_storage_type() -> Option<String> {
     Some("json".to_string())
 }
 
-/// Degrades to `None` (rather than panicking) when the home directory can't
-/// be determined, e.g. in a test/CI environment with `$HOME` pointed at a
-/// nonexistent path. `Config::default()` is now reachable from many more
-/// places than before this fix, so a panic here would be much easier to hit.
+/// The directory this application keeps its own files in: the config file,
+/// and - unless `storage.path` says otherwise - the task data beside it.
+///
+/// The location is platform-conditional because the README, which is this
+/// project's specification, documents two of them: `~/.config/trt` on Unix
+/// and `C:\Users\<username>\AppData\Roaming\trt` on Windows. Three places
+/// spelled the Unix shape out unconditionally instead (the two below, plus
+/// `main::storage_dir`), which was wrong on Windows twice over. It is not
+/// where a Windows user expects an application's files to be, and `~/.config`
+/// does not exist on a fresh Windows profile - so the *default* storage path
+/// was one `validate_storage_path` would refuse, since it rejects any path
+/// whose parent directory is missing. A default the validator rejects is a
+/// bug on its own, whatever anyone thinks of the location.
+///
+/// Deliberately not `dirs::config_dir()` unconditionally, which would be
+/// shorter and would need no `cfg` at all: on macOS that resolves to
+/// `~/Library/Application Support`, which the README does not claim and which
+/// is not where command-line tools on macOS conventionally keep their files,
+/// and on Linux it follows `$XDG_CONFIG_HOME` when that is set, so the
+/// default would stop being the literal `~/.config/trt` the README
+/// documents. Silently relocating existing installs to buy one less branch is
+/// the worse trade.
+pub fn config_root() -> Option<PathBuf> {
+    // `dirs::config_dir()` is `{FOLDERID_RoamingAppData}` on Windows - the
+    // `AppData\Roaming` the README names - and Windows creates it for every
+    // user profile, so this default's parent exists and the validator accepts
+    // it.
+    #[cfg(windows)]
+    {
+        dirs::config_dir().map(|config_dir| config_dir.join("trt"))
+    }
+    // `~/.config` on Linux *and* macOS, built from the home directory rather
+    // than taken from `dirs::config_dir()` - the two coincide only on a Linux
+    // box with no `$XDG_CONFIG_HOME` set, per the reasoning above.
+    #[cfg(not(windows))]
+    {
+        dirs::home_dir().map(|home| home.join(".config").join("trt"))
+    }
+}
+
+/// Where `trt-config.json` lives when `--config` (or `TRT_CONFIG`)
+/// doesn't say otherwise: inside `config_root()`, so a default install keeps
+/// its configuration in the same directory as its data.
+fn default_config_file_path() -> Option<PathBuf> {
+    config_root().map(|root| root.join("trt-config.json"))
+}
+
+/// Degrades to `None` (rather than panicking) when the platform's config
+/// directory can't be determined, e.g. in a test/CI environment with `$HOME`
+/// pointed at a nonexistent path. `Config::default()` is now reachable from
+/// many more places than before this fix, so a panic here would be much
+/// easier to hit.
 fn default_storage_path() -> Option<String> {
-    dirs::home_dir().map(|home| {
-        home.join(".config")
-            .join("trt")
-            .to_string_lossy()
-            .to_string()
-    })
+    config_root().map(|root| root.to_string_lossy().to_string())
 }
 
 fn default_priority() -> Option<String> {
@@ -269,8 +312,13 @@ impl ConfigManager {
         let config_path = if let Some(path) = config_path {
             path.to_path_buf()
         } else {
-            let home = dirs::home_dir().expect("Could not determine home directory");
-            home.join(".config").join("trt").join("trt-config.json")
+            // Still a panic here, where `default_storage_path` returns `None`
+            // instead: with no `--config` and no config directory there is no
+            // file to open and nothing to degrade to, whereas a missing
+            // *storage* default is only one link in a fallback chain. This is
+            // also the single startup path, run once, rather than something
+            // `Config::default()` can reach from anywhere.
+            default_config_file_path().expect("Could not determine the configuration directory")
         };
 
         let storage =
@@ -492,7 +540,7 @@ mod tests {
 
         // Test setting storage path.
         //
-        // The path comes from the TempDir rather than a hardcoded
+        // The path comes from the `TempDir` rather than a hardcoded
         // `~/.config/...` because `validate_storage_path` rejects a path whose
         // parent does not exist. `~/.config` is a Unix convention that happens
         // to exist on the Linux and macOS runners and does not exist on a
@@ -624,6 +672,45 @@ mod tests {
         assert_eq!(unset.storage_path, None);
         assert_eq!(unset.default_category, None);
         assert_eq!(unset.default_priority, None);
+    }
+
+    /// The default storage location is the platform root the README
+    /// documents: `~/.config` on Unix, the roaming `AppData` directory on
+    /// Windows. The expected value is derived from the same `dirs` lookups
+    /// rather than written out as a literal, so this holds on all three
+    /// platforms without pinning a separator or depending on any particular
+    /// directory existing.
+    #[test]
+    fn test_default_storage_path_uses_the_documented_platform_root() {
+        let expected = if cfg!(windows) {
+            dirs::config_dir()
+        } else {
+            dirs::home_dir().map(|home| home.join(".config"))
+        }
+        .map(|root| root.join("trt"));
+
+        assert_eq!(default_storage_path().map(PathBuf::from), expected);
+    }
+
+    /// The config file and the default storage directory have to come from
+    /// one root. They used to be assembled separately, each with its own
+    /// hardcoded `.config`, which is what let a platform be got wrong in one
+    /// place without the other - and, in the event, wrong in both.
+    #[test]
+    fn test_the_config_file_lives_in_the_default_storage_directory() {
+        let storage_root = default_storage_path()
+            .map(PathBuf::from)
+            .expect("no platform configuration directory");
+        let config_file = default_config_file_path().expect("no platform configuration directory");
+
+        assert_eq!(config_file.parent(), Some(storage_root.as_path()));
+        // Compared as a whole component (`file_name`) rather than as a string
+        // suffix, so the assertion says nothing about the separator in front
+        // of it.
+        assert_eq!(
+            config_file.file_name(),
+            Some(std::ffi::OsStr::new("trt-config.json"))
+        );
     }
 
     /// A fresh config (nothing stored) must report the first-run

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,12 @@ pub enum CliError {
     MalformedKeyValue(String),
     #[error("unknown storage.type '{0}': expected one of json, sqlite")]
     UnknownStorageType(String),
-    #[error("could not determine the home directory; set storage.path explicitly")]
-    NoHomeDirectory,
+    /// Not "no home directory": the directory the defaults hang off is the
+    /// platform's config directory, which is the home directory only on Unix
+    /// (see `config::config_root`), so naming `$HOME` would send a Windows
+    /// user looking in the wrong place.
+    #[error("could not determine the configuration directory; set storage.path explicitly")]
+    NoConfigDirectory,
     /// README: category context lets commands "omit the --category
     /// argument" - but only once one has actually been set via `category
     /// use`. `CheckAll`/`UncheckAll` and the simple `move` syntax have no
@@ -295,9 +299,9 @@ fn offer_default_categories(
 
 /// Builds the task storage backend described by the current configuration.
 ///
-/// `storage.path` is the storage *location* (a directory, per the README's
-/// `~/.config/trt` default); the data file inside it is named after the
-/// chosen backend.
+/// `storage.path` is the storage *location* (a directory, defaulting to the
+/// platform config root the README documents - see `config::config_root`);
+/// the data file inside it is named after the chosen backend.
 ///
 /// Also sweeps up anything overdue for automatic purging under
 /// `deleted-task-lifespan` before handing the storage back. This
@@ -330,13 +334,15 @@ fn configured_storage_type(config_manager: &ConfigManager) -> Result<StorageType
 
 /// The `storage.path` *directory* every backend keeps its data file in. See
 /// `StorageType::data_file_name` for why the file name varies by backend.
+///
+/// The fallback goes through `config::config_root` rather than assembling a
+/// path of its own: the default location is platform-dependent (see that
+/// function), and a second, independent spelling of it is how the Unix-only
+/// shape survived in three places at once.
 fn storage_dir(config_manager: &ConfigManager) -> Result<PathBuf, CliError> {
     match config_manager.get("storage.path") {
         Some(path) => Ok(PathBuf::from(shellexpand::tilde(&path).as_ref())),
-        None => Ok(dirs::home_dir()
-            .ok_or(CliError::NoHomeDirectory)?
-            .join(".config")
-            .join("trt")),
+        None => config::config_root().ok_or(CliError::NoConfigDirectory),
     }
 }
 

--- a/tests/config_commands.rs
+++ b/tests/config_commands.rs
@@ -105,15 +105,28 @@ fn fresh_install_reports_documented_defaults() {
     );
     let (_, storage_path, is_default) = find(&entries, "storage.path");
     assert!(*is_default, "{out}");
-    // Compared as path components rather than as a string suffix. The value is
-    // rendered with the platform's separator, so a literal "/.config/trt"
-    // asserts the separator as much as the path and fails on Windows against a
-    // perfectly correct `C:\Users\...\.config\trt`. `Path::ends_with` matches
-    // whole components and is separator-agnostic.
-    let expected_tail = Path::new(".config").join("trt");
-    assert!(
-        Path::new(storage_path).ends_with(&expected_tail),
-        "expected an expanded ~/.config/trt path, got {storage_path}"
+    // The expected root is platform-dependent - the README documents
+    // `~/.config` on Unix and `AppData\Roaming` on Windows - so it is derived
+    // from the same `dirs` lookup the binary makes instead of being written
+    // out. Comparing `Path`s rather than strings also keeps the assertion off
+    // the platform's separator: a literal `"/.config/trt"` suffix asserts
+    // the separator as much as the path, and fails on Windows against a
+    // perfectly correct `...\AppData\Roaming\trt`.
+    let expected_storage_path = if cfg!(windows) {
+        // `HOME` doesn't steer `dirs` on Windows, so the child process
+        // resolves the same roaming `AppData` directory this test does.
+        dirs::config_dir().expect("no roaming AppData directory")
+    } else {
+        // `dirs::home_dir()` reads `$HOME` on Unix and `run` points that at
+        // `home_guard()`, so the child's default is fully determined here -
+        // no ambient home directory takes part in the comparison.
+        trt.home_guard().join(".config")
+    }
+    .join("trt");
+    assert_eq!(
+        Path::new(storage_path),
+        expected_storage_path,
+        "unexpected default storage.path in {out}"
     );
     assert_eq!(
         find(&entries, "default-category"),

--- a/tests/deleted_commands.rs
+++ b/tests/deleted_commands.rs
@@ -66,13 +66,16 @@ impl Trt {
 
     /// The exact path `open_storage` would create task data under if it ever
     /// fell back to `$HOME` instead of the configured `storage.path`
-    /// (`main::open_storage`: `$HOME/.config/trt`). Asserting on this
-    /// precise, app-owned subpath - rather than on `home_guard()` itself -
-    /// is deliberate: some environments (e.g. a CI sandbox) may already have
-    /// unrelated content sitting at the guard root for reasons outside this
-    /// codebase's control, which would make "the guard root doesn't exist"
-    /// a false failure. What actually matters, and what this proves, is
-    /// that trt itself never wrote anything there.
+    /// (`config::config_root`: `$HOME/.config/trt` on the platforms whose
+    /// default hangs off `$HOME` at all - on Windows it hangs off the roaming
+    /// `AppData` directory instead, which no environment variable set here
+    /// can redirect, so there the guard is simply never reached). Asserting
+    /// on this precise, app-owned subpath - rather than on `home_guard()`
+    /// itself - is deliberate: some environments (e.g. a CI sandbox) may
+    /// already have unrelated content sitting at the guard root for reasons
+    /// outside this codebase's control, which would make "the guard root
+    /// doesn't exist" a false failure. What actually matters, and what this
+    /// proves, is that trt itself never wrote anything there.
     fn app_home_marker(&self) -> std::path::PathBuf {
         self.home_guard().join(".config").join("trt")
     }


### PR DESCRIPTION
Closes #61.

The default config and data location was `~/.config/trt` on every platform, while the README documents `C:\Users\<username>\AppData\Roaming\trt` for Windows. `dirs::home_dir()` resolves correctly there — it was the unconditional `.join(".config")` that was wrong.

## Why this is more than a location preference

`validate_storage_path` rejects any path whose parent directory does not exist. `~/.config` does not exist on a fresh Windows profile, so the **default** `storage.path` was one that `config set storage.path` would have refused. A default the validator rejects is a bug on its own terms, whatever anyone thinks of where files should live.

## What changed

The path was spelled out in **three** places, not the two the issue named — `default_storage_path`, `ConfigManager::new`, and `main::storage_dir`. All three now go through one `config::config_root()`:

| Platform | Before | After |
| --- | --- | --- |
| Linux | `~/.config/trt` | `~/.config/trt` (unchanged) |
| macOS | `~/.config/trt` | `~/.config/trt` (unchanged) |
| Windows | `C:\Users\<u>\.config\trt` | `%APPDATA%\trt` |

`dirs::config_dir()` unconditionally would have been shorter and needed no `cfg`, and was rejected for two reasons rather than one:

- macOS would move to `~/Library/Application Support`, which the README does not claim and which is not where CLI tools there conventionally keep files.
- **On Linux it follows `$XDG_CONFIG_HOME`**, so the default would stop being the literal `~/.config/trt` the README documents whenever that variable is set. This was confirmed by reading the vendored `dirs-5.0.1` source (`lin.rs`, `mac.rs`, `win.rs`) rather than assumed.

`ConfigManager::new` keeps its panic and `default_storage_path` keeps its `None` — that distinction is deliberate and the reasoning is now recorded next to each. `CliError::NoHomeDirectory` becomes `NoConfigDirectory`, since "home directory" is the wrong thing to name on Windows.

Docs: the README's first-run paragraph had the Windows path with stray escaping and the Unix path in Windows separators; the `storage.path` table row listed one platform only. `CLAUDE.md`'s opening line stated the single old path.

## Tests

173 → 175. Two added, none removed.

The two Windows test fixes from #60 are **superseded rather than kept**. Both now derive their expected value from the same `dirs` lookups the binary makes, instead of hardcoding a path that only happened to be right on one platform — which is what made them fragile to begin with. New coverage asserts the default root per-platform under `cfg!(windows)`, and that the config file's parent is the storage root.

## Verification

```
cargo fmt --all -- --check     # clean
cargo clippy -- -D warnings    # clean
cargo test                     # 175 passed, 0 failed (113/15/3/14/7/6/17)
```

End-to-end against a scratch `$HOME`, confirming Linux behaviour is unchanged rather than trusting the diff:

```
~/.config/trt/trt-config.json
~/.config/trt/trt-data.json
```

**Not verified locally:** no Windows or macOS execution — this container is Linux only, and `rusqlite` is bundled C so cross-compiling isn't viable here. The Windows path is correct by construction and by `dirs`' source-confirmed behaviour. The matrix added in #60 is what actually proves it, and it runs on this PR.

## One residual gap, deliberately not fixed here

On **macOS**, `~/.config` may not exist on a fresh machine either, so the default remains theoretically validator-rejectable there. That is pre-existing Unix behaviour which the chosen option keeps on purpose; closing it means having validation or `open_storage` create the root rather than refuse it, which is a separate change and worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyoC58k1sv3ia8jEDen2ig

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyoC58k1sv3ia8jEDen2ig)_